### PR TITLE
update to teams info function/Pkgdown

### DIFF
--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -109,7 +109,7 @@ NULL
 #'
 #'   try(cfbd_team_info(year = 2019))
 #' }
-cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = NULL) {
+cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recent_cfb_season()) {
   if (!is.null(conference)) {
     # # Check conference parameter in conference abbreviations, if not NULL
     # Encode conference parameter for URL, if not NULL

--- a/man/cfbd_team_info.Rd
+++ b/man/cfbd_team_info.Rd
@@ -4,7 +4,11 @@
 \alias{cfbd_team_info}
 \title{\strong{Team info lookup}}
 \usage{
-cfbd_team_info(conference = NULL, only_fbs = TRUE, year = NULL)
+cfbd_team_info(
+  conference = NULL,
+  only_fbs = TRUE,
+  year = most_recent_cfb_season()
+)
 }
 \arguments{
 \item{conference}{(\emph{String} optional): Conference abbreviation - Select a valid FBS conference

--- a/vignettes/nth-rated-recruit.Rmd
+++ b/vignettes/nth-rated-recruit.Rmd
@@ -30,7 +30,8 @@ pacman::p_load(dplyr, ggplot2,cfbfastR)
 To create the plot I'm going to use two functions from ```cfbfastR```. The first is the ```cfbd_team_info``` function. I'm going to pass ```"B1G"``` to the function for the ```conference``` argument to get info for just Big Ten teams. The next function I'm going to use is the ```cfbd_recruiting_player``` function. The apply function allows me to run the given function for each item in the data frame I pass to it. In this case I run it for each team in the Big Ten. I'm calling this function four times to get each year's class. I'll combine all of these into one large data frame with every team's recruits. For the sake of simplicity, I am only using High School recruits as shown by the ```recruit_type``` argument. You can also get Prep School recruits (```recruit_type = "PrepSchool"```) or junior college recruits (```recruit_type = "JUCO"```).
 
 ```{r cfb}
-teams <- cfbfastR::cfbd_team_info(conference = "B1G")
+teams <- cfbfastR::cfbd_team_info() %>% 
+  dplyr::filter(conference = "Big Ten")
 schools <- teams$school
 yr <- cfbfastR:::most_recent_cfb_season()
 year_range <- (yr-3):yr


### PR DESCRIPTION
adding a year = most_recent_cfb_season() default. Updated `nth-rated-recruit` vignette to account for odd variation between returns when only conference is selected. Believe this is a @CFBData issue