### PR TITLE
Remove iterator override

### DIFF
--- a/vignettes/cfbd_plays.Rmd
+++ b/vignettes/cfbd_plays.Rmd
@@ -36,8 +36,6 @@ weekly_year_df <- expand.grid(year = year_vector, week = week_vector)
 tictoc::tic()
 year_split <- split(weekly_year_df, weekly_year_df$year)
 for (i in 1:length(year_split)) {
-  i <- 1
-  
   progressr::with_progress({
     year_split[[i]] <- year_split[[i]] %>%
       dplyr::mutate(


### PR DESCRIPTION
When I use the `cfbd_plays` script, but adding additional years (e.g. `year_vector <- 2020:2021`), it fails with this error:
```
Error in `tidyr::unnest()`:
! Can't subset columns that don't exist.
x Column `pbp` doesn't exist.
```

When I remove the `i <- 1` assignment, it succeeds. 

This PR removes the unnecessary assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved efficiency in the processing of data within the app by removing redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->