### PR TITLE
Adjust `cfbd_*` functions for CFBD API V2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Authors@R: c(
     person("Keegan", "Abdoo", , "kabdoo@draft.ly", role = "ctb"),
     person("Matt", "Spencer", , "maatspencer@gmail.com", role = "ctb"),
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = "ctb"),
-    person("John", "Edwards", , "edwards1860@gmail.com", role = "ctb")
+    person("John", "Edwards", , "edwards1860@gmail.com", role = "ctb"),
+    person("Brad", "Hill", , "bradhill119@gmail.com", role = "ctb")
   )
 Description: A utility to quickly obtain clean and tidy college football
     data. Serves as a wrapper around the

--- a/R/cfbd_betting.R
+++ b/R/cfbd_betting.R
@@ -1,9 +1,9 @@
 
 #' @title **CFBD Betting Lines Endpoint Overview**
 #' @description **Get betting lines information for games**
-#' @param game_id (*Integer* optional): Game ID filter for querying a single game \cr
+#' @param game_id (*Integer* optional): Game ID filter for querying a single game. Required if year not provided \cr
 #' Can be found using the [cfbd_game_info()] function
-#' @param year (*Integer* required): Year, 4 digit format(*YYYY*)
+#' @param year (*Integer* optional): Year, 4 digit format(*YYYY*). Required if game_id not provided
 #' @param week (*Integer* optional): Week - values from 1-15, 1-14 for seasons pre-playoff (i.e. 2013 or earlier)
 #' @param season_type (*String* default regular): Select Season Type: regular or postseason
 #' @param team (*String* optional): D-I Team

--- a/R/cfbd_betting.R
+++ b/R/cfbd_betting.R
@@ -61,14 +61,21 @@ cfbd_betting_lines <- function(game_id = NULL,
                                conference = NULL,
                                line_provider=NULL) {
 
+  # Validation Lists ----
+  providers <- c(
+    'teamrankings', 'numberfire', 'consensus', 'Caesars', 'Bovada',
+    'SugarHouse', 'William Hill (New Jersey)', 'Caesars (Pennsylvania)',
+    'Caesars Sportsbook (Colorado)', 'ESPN Bet', 'DraftKings'
+  )
+
   # Validation ----
   validate_api_key()
   validate_reqs(game_id, year)
   validate_year(year)
   validate_week(week)
   validate_season_type(season_type)
-  validate_game_id(game_id)
-  validate_list(line_provider, c("Caesars", "consensus", "numberfire", "teamrankings"))
+  validate_id(game_id)
+  validate_list(line_provider, providers)
 
   # Team Name Handling ----
   team <- handle_accents(team)

--- a/R/cfbd_betting.R
+++ b/R/cfbd_betting.R
@@ -39,7 +39,6 @@
 #'
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -81,25 +80,13 @@ cfbd_betting_lines <- function(game_id = NULL,
     cli::cli_abort("Enter valid season_type: regular or postseason")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(home_team)) {
-    # Encode home_team parameter for URL, if not NULL
-    home_team <- utils::URLencode(home_team, reserved = TRUE)
+    home_team <- handle_accents(home_team)
   }
   if (!is.null(away_team)) {
-    # Encode away_team parameter for URL, if not NULL
-    away_team <- utils::URLencode(away_team, reserved = TRUE)
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    away_team <- handle_accents(away_team)
   }
   if (!is.null(line_provider) &&  is.character(line_provider) &&
       !(line_provider %in% c("Caesars", "consensus", "numberfire", "teamrankings"))) {

--- a/R/cfbd_betting.R
+++ b/R/cfbd_betting.R
@@ -135,22 +135,7 @@ cfbd_betting_lines <- function(game_id = NULL,
         jsonlite::fromJSON(flatten = TRUE) %>%
         purrr::map_if(is.data.frame, list) %>%
         dplyr::as_tibble() %>%
-        tidyr::unnest("lines") %>%
-        dplyr::mutate(
-            overUnder = dplyr::case_when(
-                .data$overUnder == "null" ~ NA_real_,
-                .default = .data$overUnder
-            ),
-            spread = dplyr::case_when(
-                .data$spread == "null" ~ NA_real_,
-                .default = .data$spread
-            ),
-            formattedSpread = dplyr::case_when(
-                is.na(.data$spread) ~ NA_character_,
-                .default = .data$formattedSpread
-            )
-        )
-
+        tidyr::unnest("lines")
 
 
       if (!is.null(line_provider)) {

--- a/R/cfbd_betting.R
+++ b/R/cfbd_betting.R
@@ -83,7 +83,7 @@ cfbd_betting_lines <- function(game_id = NULL,
   away_team <- handle_accents(away_team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/lines?"
+  base_url <- "https://api.collegefootballdata.com/lines"
   query_params <- list(
     "gameId" = game_id,
     "year" = year,

--- a/R/cfbd_coaches.R
+++ b/R/cfbd_coaches.R
@@ -80,15 +80,16 @@ cfbd_coaches <- function(first = NULL,
   base_url <- "https://api.collegefootballdata.com/coaches?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "first=", first,
-    "&last=", last,
-    "&team=", team,
-    "&year=", year,
-    "&minYear=", min_year,
-    "&maxYear=", max_year
+  query_params <- list(
+    "first" = first,
+    "last" = last,
+    "team" = team,
+    "year" = year,
+    "minYear" = min_year,
+    "maxYear" = max_year
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)

--- a/R/cfbd_coaches.R
+++ b/R/cfbd_coaches.R
@@ -31,7 +31,6 @@
 #' @keywords Coaches
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -48,21 +47,8 @@ cfbd_coaches <- function(first = NULL,
                          year = NULL,
                          min_year = NULL,
                          max_year = NULL) {
-  if (!is.null(first)) {
-    # Encode first parameter for URL if not NULL
-    first <- utils::URLencode(first, reserved = TRUE)
-  }
-  if (!is.null(last)) {
-    # Encode last parameter for URL if not NULL
-    last <- utils::URLencode(last, reserved = TRUE)
-  }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(year) && !(is.numeric(year) && nchar(year) == 4)) {
     # Check if year is numeric, if not NULL

--- a/R/cfbd_coaches.R
+++ b/R/cfbd_coaches.R
@@ -47,25 +47,18 @@ cfbd_coaches <- function(first = NULL,
                          year = NULL,
                          min_year = NULL,
                          max_year = NULL) {
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
-  if (!is.null(year) && !(is.numeric(year) && nchar(year) == 4)) {
-    # Check if year is numeric, if not NULL
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(min_year) && !(is.numeric(min_year) && nchar(min_year) == 4)) {
-    ## check if min_year is numeric
-    cli::cli_abort("Enter valid min_year as integer in 4 digit format (YYYY)")
-  }
-  if (!is.null(max_year) && !(is.numeric(max_year) && nchar(max_year) == 4)) {
-    ## check if max_year is numeric
-    cli::cli_abort("Enter valid max_year as integer in 4 digit format (YYYY)")
-  }
 
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
+  validate_year(min_year)
+  validate_year(max_year)
+
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/coaches?"
-
-  # Create full url using base and input arguments
   query_params <- list(
     "first" = first,
     "last" = last,
@@ -74,23 +67,14 @@ cfbd_coaches <- function(first = NULL,
     "minYear" = min_year,
     "maxYear" = max_year
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame

--- a/R/cfbd_coaches.R
+++ b/R/cfbd_coaches.R
@@ -58,7 +58,7 @@ cfbd_coaches <- function(first = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/coaches?"
+  base_url <- "https://api.collegefootballdata.com/coaches"
   query_params <- list(
     "first" = first,
     "last" = last,

--- a/R/cfbd_conferences.R
+++ b/R/cfbd_conferences.R
@@ -23,22 +23,19 @@
 #'   try(cfbd_conferences())
 #' }
 cfbd_conferences <- function() {
-  full_url <- "https://api.collegefootballdata.com/conferences"
 
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
+  # Validation ----
+  validate_api_key()
+
+  # Query API ----
+  full_url <- "https://api.collegefootballdata.com/conferences"
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame

--- a/R/cfbd_draft.R
+++ b/R/cfbd_draft.R
@@ -56,26 +56,18 @@ NULL
 #'
 cfbd_draft_teams <- function() {
 
-  base_url <- "https://api.collegefootballdata.com/draft/teams"
+  # Validation ----
+  validate_api_key()
 
-  # Create full url using base and input arguments
-  full_url <- base_url
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
+  # Query API ----
+  full_url <- "https://api.collegefootballdata.com/draft/teams"
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame
@@ -124,25 +116,18 @@ cfbd_draft_teams <- function() {
 #'
 cfbd_draft_positions <- function() {
 
-  base_url <- "https://api.collegefootballdata.com/draft/positions"
+  # Validation ----
+  validate_api_key()
 
-  # Create full url using base and input arguments
-  full_url <- base_url
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
+  # Query API ----
+  full_url <- "https://api.collegefootballdata.com/draft/positions"
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame
@@ -222,17 +207,16 @@ cfbd_draft_picks <- function(year = NULL,
                              college = NULL,
                              conference = NULL,
                              position = NULL) {
-  if (!is.null(year) & !(is.numeric(year) & nchar(year) == 4)) {
-    # Check if year is numeric, if not NULL
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(college)) {
-    college <- handle_accents(college)
-  }
 
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
+
+  # Team Name Handling ----
+  college <- handle_accents(college)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/draft/picks?"
-
-  # Create full url using base and input arguments
   query_params <- list(
     "year" = year,
     "nflTeam" = nfl_team,
@@ -240,24 +224,14 @@ cfbd_draft_picks <- function(year = NULL,
     "conference" = conference,
     "position" = position
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame

--- a/R/cfbd_draft.R
+++ b/R/cfbd_draft.R
@@ -251,14 +251,16 @@ cfbd_draft_picks <- function(year = NULL,
   base_url <- "https://api.collegefootballdata.com/draft/picks?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&nflTeam=", nfl_team,
-    "&college=", college,
-    "&conference=", conference,
-    "&position=", position
+  query_params <- list(
+    "year" = year,
+    "nflTeam" = nfl_team,
+    "college" = college,
+    "conference" = conference,
+    "position" = position
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
+
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 

--- a/R/cfbd_draft.R
+++ b/R/cfbd_draft.R
@@ -216,7 +216,7 @@ cfbd_draft_picks <- function(year = NULL,
   college <- handle_accents(college)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/draft/picks?"
+  base_url <- "https://api.collegefootballdata.com/draft/picks"
   query_params <- list(
     "year" = year,
     "nflTeam" = nfl_team,

--- a/R/cfbd_draft.R
+++ b/R/cfbd_draft.R
@@ -45,7 +45,6 @@ NULL
 #' @keywords NFL Teams
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom janitor clean_names
@@ -114,7 +113,6 @@ cfbd_draft_teams <- function() {
 #' @keywords NFL Positions
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom janitor clean_names
@@ -208,7 +206,6 @@ cfbd_draft_positions <- function() {
 #' @keywords NFL Draft Picks
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom janitor clean_names
@@ -229,23 +226,8 @@ cfbd_draft_picks <- function(year = NULL,
     # Check if year is numeric, if not NULL
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
-  if (!is.null(nfl_team)) {
-    # Encode team parameter for URL if not NULL
-    nfl_team <- utils::URLencode(nfl_team, reserved = TRUE)
-  }
   if (!is.null(college)) {
-    if (college == "San Jose State") {
-      college <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      college <- utils::URLencode(college, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    conference <- utils::URLencode(conference, reserved = TRUE)
-  }
-  if (!is.null(position)) {
-    position <- utils::URLencode(position, reserved = TRUE)
+    college <- handle_accents(college)
   }
 
   base_url <- "https://api.collegefootballdata.com/draft/picks?"

--- a/R/cfbd_drives.R
+++ b/R/cfbd_drives.R
@@ -87,7 +87,7 @@ cfbd_drives <- function(year,
   defense_team <- handle_accents(defense_team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/drives?"
+  base_url <- "https://api.collegefootballdata.com/drives"
   query_params <- list(
     "year" = year,
     "seasonType" = season_type,

--- a/R/cfbd_drives.R
+++ b/R/cfbd_drives.R
@@ -179,7 +179,8 @@ cfbd_drives <- function(year,
           "time_seconds_end" = "endTime.seconds"
         ) %>%
         dplyr::mutate(time_minutes_elapsed = NA,
-                      time_seconds_elapsed = NA)
+                      time_seconds_elapsed = NA) %>%
+        janitor::clean_names()
 
       # 2021 games with pbp data from another (non-ESPN) source include extra unclear columns for hours.
       # Minutes and seconds from these games are also suspect

--- a/R/cfbd_drives.R
+++ b/R/cfbd_drives.R
@@ -53,7 +53,6 @@
 #' @keywords Drives
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -90,49 +89,14 @@ cfbd_drives <- function(year,
     cli::cli_abort("Enter valid week 1-15 \n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(offense_team)) {
-    if (offense_team == "San Jose State") {
-      offense_team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      offense_team <- utils::URLencode(offense_team, reserved = TRUE)
-    }
+    offense_team <- handle_accents(offense_team)
   }
   if (!is.null(defense_team)) {
-    if (defense_team == "San Jose State") {
-      defense_team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      defense_team <- utils::URLencode(defense_team, reserved = TRUE)
-    }
+    defense_team <- handle_accents(defense_team)
   }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
-  }
-  if (!is.null(offense_conference)) {
-    # # Check offense_conference parameter in conference abbreviations, if not NULL
-    # Encode offense_conference parameter for URL, if not NULL
-    offense_conference <- utils::URLencode(offense_conference, reserved = TRUE)
-  }
-  if (!is.null(defense_conference)) {
-    # # Check defense_conference parameter in conference abbreviations, if not NULL
-    # Encode defense_conference parameter for URL, if not NULL
-    defense_conference <- utils::URLencode(defense_conference, reserved = TRUE)
-  }
-  if (!is.null(division)) {
-    # # Check division parameter
-    division <- utils::URLencode(division, reserved = TRUE)
-  }
-
 
   base_url <- "https://api.collegefootballdata.com/drives?"
 

--- a/R/cfbd_games.R
+++ b/R/cfbd_games.R
@@ -191,18 +191,19 @@ cfbd_game_info <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/games?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&seasonType=", season_type,
-    "&team=", team,
-    "&home=", home_team,
-    "&away=", away_team,
-    "&conference=", conference,
-    "&division=", division,
-    "&id=", game_id
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "seasonType" = season_type,
+    "team" = team,
+    "home" = home_team,
+    "away" = away_team,
+    "conference" = conference,
+    "division" = division,
+    "id" = game_id
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -327,14 +328,15 @@ cfbd_game_weather <- function(year,
   }
   base_url <- "https://api.collegefootballdata.com/games/weather?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&seasonType=", season_type,
-    "&team=", team,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "seasonType" = season_type,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -407,10 +409,11 @@ cfbd_calendar <- function(year) {
 
   base_url <- "https://api.collegefootballdata.com/calendar?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year
+  query_params <- list(
+    "year" = year
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -530,16 +533,17 @@ cfbd_game_media <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/games/media?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&seasonType=", season_type,
-    "&team=", team,
-    "&conference=", conference,
-    "&mediaType=", media_type,
-    "&classification=", division
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "seasonType" = season_type,
+    "team" = team,
+    "conference" = conference,
+    "mediaType" = media_type,
+    "classification" = division
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -699,10 +703,11 @@ cfbd_game_box_advanced <- function(game_id, long = FALSE) {
 
   base_url <- "https://api.collegefootballdata.com/game/box/advanced?"
 
-  full_url <- paste0(
-    base_url,
-    "gameId=", game_id
+  query_params <- list(
+    "id" = game_id
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -957,16 +962,17 @@ cfbd_game_player_stats <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/games/players?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&seasonType=", season_type,
-    "&team=", team,
-    "&conference=", conference,
-    "&category=", category,
-    "&gameId=", game_id
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "seasonType" = season_type,
+    "team" = team,
+    "conference" = conference,
+    "category" = category,
+    "gameId" = game_id
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -1126,7 +1132,6 @@ cfbd_game_player_stats <- function(year,
           "athlete_id" = "id",
           "athlete_name" = "name",
           "team_points" = "points",
-          "team" = "school",
           "value" = "stat"
         ) %>%
         dplyr::select(-dplyr::any_of(c("category", "stat_category"))) %>%
@@ -1243,12 +1248,13 @@ cfbd_game_records <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/records?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -1322,7 +1328,7 @@ cfbd_game_records <- function(year,
 #' @return [cfbd_game_team_stats()] - A data frame with 78 variables:
 #' \describe{
 #'   \item{`game_id`: integer.}{Referencing game id.}
-#'   \item{`school`: character.}{Team name.}
+#'   \item{`team`: character.}{Team name.}
 #'   \item{`conference`: character.}{Conference of the team.}
 #'   \item{`home_away`: character.}{Home/Away Flag.}
 #'   \item{`opponent`: character.}{Opponent team name.}
@@ -1469,16 +1475,17 @@ cfbd_game_team_stats <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/games/teams?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&seasonType=", season_type,
-    "&team=", team,
-    "&conference=", conference,
-    "&classification=", division,
-    "&gameId=", game_id
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "seasonType" = season_type,
+    "team" = team,
+    "conference" = conference,
+    "classification" = division,
+    "gameId" = game_id
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -1498,7 +1505,7 @@ cfbd_game_team_stats <- function(year,
 
 
       cols <- c(
-        "id", "school", "conference", "home_away",
+        "id", "team", "conference", "home_away",
         "points", "rushing_t_ds", "punt_return_yards", "punt_return_t_ds",
         "punt_returns", "passing_t_ds", "kicking_points",
         "interception_yards", "interception_t_ds", "passes_intercepted",
@@ -1560,11 +1567,11 @@ cfbd_game_team_stats <- function(year,
                            suffix = c("", "_allowed")
           ) %>%
           dplyr::rename(
-            "opponent" = "school_allowed",
+            "opponent" = "team_allowed",
             "opponent_conference" = "conference_allowed")
 
         cols1 <- c(
-          "game_id", "school", "conference", "home_away","opponent","opponent_conference",
+          "game_id", "team", "conference", "home_away","opponent","opponent_conference",
           "points", "total_yards", "net_passing_yards",
           "completion_attempts", "passing_tds", "yards_per_pass",
           "passes_intercepted", "interception_yards", "interception_tds",
@@ -1593,7 +1600,7 @@ cfbd_game_team_stats <- function(year,
           team <- URLdecode(team)
 
           df <- df %>%
-            dplyr::filter(.data$school == team) %>%
+            dplyr::filter(.data$team == team) %>%
             dplyr::select(dplyr::all_of(cols1))
 
 
@@ -1616,7 +1623,7 @@ cfbd_game_team_stats <- function(year,
         }
       } else {
         cols2 <- c(
-          "game_id", "school", "conference", "home_away",
+          "game_id", "team", "conference", "home_away",
           "points", "total_yards", "net_passing_yards",
           "completion_attempts", "passing_tds", "yards_per_pass",
           "passes_intercepted", "interception_yards", "interception_tds",
@@ -1633,7 +1640,7 @@ cfbd_game_team_stats <- function(year,
           team <- URLdecode(team <- team)
 
           df <- df %>%
-            dplyr::filter(.data$school == team) %>%
+            dplyr::filter(.data$team == team) %>%
             dplyr::select(dplyr::all_of(cols2))
 
         } else if (!is.null(conference)) {

--- a/R/cfbd_games.R
+++ b/R/cfbd_games.R
@@ -117,7 +117,6 @@ NULL
 #' @keywords Game Info
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -152,37 +151,13 @@ cfbd_game_info <- function(year,
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(home_team)) {
-    if (home_team == "San Jose State") {
-      home_team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode home_team parameter for URL if not NULL
-      home_team <- utils::URLencode(home_team, reserved = TRUE)
-    }
+    home_team <- handle_accents(home_team)
   }
   if (!is.null(away_team)) {
-    if (away_team == "San Jose State") {
-      away_team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      away_team <- utils::URLencode(away_team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
-  }
-  if (!is.null(division)) {
-    # # Check division parameter
-    division <- utils::URLencode(division, reserved = TRUE)
+    away_team <- handle_accents(away_team)
   }
   if (!is.null(game_id) && !is.numeric(game_id)) {
     # Check if game_id is numeric, if not NULL
@@ -290,7 +265,6 @@ cfbd_game_info <- function(year,
 #' @keywords Game Weather
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -314,18 +288,9 @@ cfbd_game_weather <- function(year,
     cli::cli_abort("Enter valid season_type: regular or postseason")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
-  if (!is.null(conference)) {
-    # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
-  }
+
   base_url <- "https://api.collegefootballdata.com/games/weather?"
 
   query_params <- list(
@@ -391,7 +356,6 @@ cfbd_game_weather <- function(year,
 #' @importFrom janitor clean_names
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export
@@ -482,7 +446,6 @@ cfbd_calendar <- function(year) {
 #' @keywords Game Info
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -515,20 +478,7 @@ cfbd_game_media <- function(year,
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
-  }
-  if (!is.null(division)) {
-    # # Check division parameter
-    division <- utils::URLencode(division, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/games/media?"
@@ -681,7 +631,7 @@ cfbd_game_media <- function(year,
 #' @importFrom tibble enframe
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom stringr str_detect
@@ -889,7 +839,7 @@ cfbd_game_box_advanced <- function(game_id, long = FALSE) {
 #' @keywords Game Info
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -935,17 +885,7 @@ cfbd_game_player_stats <- function(year,
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
   if (!is.null(category)) {
     if(!(category %in% stat_categories)){
@@ -953,7 +893,6 @@ cfbd_game_player_stats <- function(year,
       cli::cli_abort("Incorrect category, potential misspelling.\nOffense: passing, receiving, rushing\nDefense: defensive, fumbles, interceptions\nSpecial Teams: punting, puntReturns, kicking, kickReturns")
     }
     # Encode conference parameter for URL, if not NULL
-    category <- utils::URLencode(category, reserved = TRUE)
   }
   if (!is.null(game_id) && !is.numeric(game_id)) {
     # Check if game_id is numeric, if not NULL
@@ -1211,7 +1150,6 @@ cfbd_game_player_stats <- function(year,
 #' @keywords Team Info
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @import dplyr
 #' @import tidyr
@@ -1233,17 +1171,7 @@ cfbd_game_records <- function(year,
     cli::cli_abort("Enter valid year (Integer): 4 digits (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # Check conference parameter in conference abbreviations, if not NULL
-    # # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/records?"
@@ -1410,7 +1338,7 @@ cfbd_game_records <- function(year,
 #' @keywords Team Game Stats
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -1447,21 +1375,7 @@ cfbd_game_team_stats <- function(year,
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
-  }
-  if (!is.null(division)) {
-    # # Check division parameter
-    division <- utils::URLencode(division, reserved = TRUE)
+    team <- handle_accents(team)
   }
   if (!is.null(game_id) && !is.numeric(game_id)) {
     # Check if game_id is numeric, if not NULL

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -99,7 +99,7 @@ cfbd_metrics_ppa_games <- function(year,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ppa/games?"
+  base_url <- "https://api.collegefootballdata.com/ppa/games"
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -214,7 +214,7 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ppa/players/games?"
+  base_url <- "https://api.collegefootballdata.com/ppa/players/games"
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -338,7 +338,7 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ppa/players/season?"
+  base_url <- "https://api.collegefootballdata.com/ppa/players/season"
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -420,7 +420,7 @@ cfbd_metrics_ppa_predicted <- function(down,
   validate_range(distance, 1, 99)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ppa/predicted?"
+  base_url <- "https://api.collegefootballdata.com/ppa/predicted"
   query_params <- list(
     "down" = down,
     "distance" = distance
@@ -516,7 +516,7 @@ cfbd_metrics_ppa_teams <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ppa/teams?"
+  base_url <- "https://api.collegefootballdata.com/ppa/teams"
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -603,7 +603,7 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/metrics/wp/pregame?"
+  base_url <- "https://api.collegefootballdata.com/metrics/wp/pregame"
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -692,7 +692,7 @@ cfbd_metrics_wp <- function(game_id) {
   validate_id(game_id)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/metrics/wp?"
+  base_url <- "https://api.collegefootballdata.com/metrics/wp"
   query_params <- list(
     "gameId" = game_id
   )

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -369,7 +369,7 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
 
       df <- df %>%
         dplyr::rename("athlete_id" = "id") %>%
-        mutate(countable_plays = NA_integer_)
+        dplyr::mutate(countable_plays = NA_integer_)
 
       df <- df %>%
         make_cfbfastR_data("Player season PPA data from CollegeFootballData.com",Sys.time())

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -73,7 +73,6 @@ NULL
 #' @keywords Teams Predicted Points
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -100,17 +99,7 @@ cfbd_metrics_ppa_games <- function(year,
     cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
   if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
     # Check if excl_garbage_time is TRUE, if not FALSE
@@ -202,7 +191,6 @@ cfbd_metrics_ppa_games <- function(year,
 #' @keywords Players Predicted Points
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -241,12 +229,7 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
     cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(position) && !(position %in% pos_groups)) {
     ## check if position in position group set
@@ -361,7 +344,6 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
 #' @keywords Players Predicted Points Season Averages
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @import dplyr
@@ -395,17 +377,7 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   if (!is.null(position) && !(position %in% pos_groups)) {
@@ -430,7 +402,7 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
   query_params <- list(
     "year" = year,
     "team" = team,
-    "conferenc" = conference,
+    "conference" = conference,
     "position" = position,
     "playerId" = athlete_id,
     "threshold" = threshold,
@@ -600,7 +572,6 @@ cfbd_metrics_ppa_predicted <- function(down,
 #' @keywords Teams Predicted Points
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @import dplyr
 #' @import tidyr
@@ -624,17 +595,7 @@ cfbd_metrics_ppa_teams <- function(year = NULL,
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference names, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
   if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
     # Check if excl_garbage_time is TRUE, if not FALSE
@@ -711,7 +672,7 @@ cfbd_metrics_ppa_teams <- function(year = NULL,
 #' @keywords Pre-game Win Probability Data
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -736,12 +697,7 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
     cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
 
   if (!(season_type %in% c("postseason", "regular"))) {
@@ -828,7 +784,7 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
 #' @keywords Win Probability Chart Data
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -146,9 +146,9 @@ cfbd_metrics_ppa_games <- function(year,
 
 #' @title
 #' **Get player game averages for predicted points added (PPA)**
-#' @param year (*Integer* required): Year, 4 digit format (*YYYY*)
-#' @param week (*Integer* optional): Week - values range from 1-15, 1-14 for seasons pre-playoff, i.e. 2013 or earlier
-#' @param team (*String* optional): D-I Team. Required if year not provided.
+#' @param year (*Integer* required): Year, 4 digit format (*YYYY*).
+#' @param week (*Integer* optional): Week - values range from 1-15, 1-14 for seasons pre-playoff, i.e. 2013 or earlier. Required if team not provided
+#' @param team (*String* optional): D-I Team. Required if week not provided.
 #' @param position (*string* optional): Position abbreviation of the player you are searching for.
 #' Position Group  - options include:
 #'  * Offense: QB, RB, FB, TE,  OL, G, OT, C, WR
@@ -202,7 +202,7 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
 
   # Validation ----
   validate_api_key()
-  validate_reqs(year, team)
+  validate_reqs(week, team)
   validate_year(year)
   validate_week(week)
   validate_list(position, pos_groups)
@@ -256,8 +256,8 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
 
 #' @title
 #' **Get player season averages for predicted points added (PPA)**
-#' @param year (*Integer* required): Year, 4 digit format (*YYYY*)
-#' @param team (*String* optional): D-I Team
+#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*). Required if athlete_id not provided
+#' @param team (*String* optional): D-I Team.
 #' @param conference (*String* optional): Conference abbreviation - S&P+ information by conference
 #' Conference abbreviations P5: ACC, B12, B1G, SEC, PAC
 #' Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC
@@ -266,7 +266,7 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
 #'  * Offense: QB, RB, FB, TE,  OL, G, OT, C, WR
 #'  * Defense: DB, CB, S, LB,  DE, DT, NT, DL
 #'  * Special Teams: K, P, LS, PK
-#' @param athlete_id (*Integer* optional): Athlete ID filter for querying a single athlete
+#' @param athlete_id (*Integer* optional): Athlete ID filter for querying a single athlete. Required if year not provided
 #' Can be found using the [cfbd_player_info()] function.
 #' @param threshold (*Integer* optional): Minimum threshold of plays.
 #' @param excl_garbage_time (*Logical* default FALSE): Select whether to exclude Garbage Time (TRUE or FALSE)
@@ -327,7 +327,7 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
 
   # Validation ----
   validate_api_key()
-  validate_reqs(year, team)
+  validate_reqs(year, athlete_id)
   validate_year(year)
   validate_list(position, pos_groups)
   validate_id(athlete_id)
@@ -457,8 +457,8 @@ cfbd_metrics_ppa_predicted <- function(down,
 
 #' @title
 #' **Get team averages for predicted points added (PPA)**
-#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*)
-#' @param team (*String* optional): D-I Team
+#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*). Required if team not provided
+#' @param team (*String* optional): D-I Team. Required if year not provided
 #' @param conference (*String* optional): Conference name - select a valid FBS conference
 #' Conference names P5: ACC,  Big 12, Big Ten, SEC, Pac-12
 #' Conference names G5 and FBS Independents: Conference USA, Mid-American, Mountain West, FBS Independents, American Athletic
@@ -689,7 +689,7 @@ cfbd_metrics_wp <- function(game_id) {
 
   # Validation ----
   validate_api_key()
-  validate_game_id(game_id)
+  validate_id(game_id)
 
   # Query API ----
   base_url <- "https://api.collegefootballdata.com/metrics/wp?"

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -119,14 +119,15 @@ cfbd_metrics_ppa_games <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/ppa/games?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&conference=", conference,
-    "&excludeGarbageTime=", excl_garbage_time
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "conference" = conference,
+    "excludeGarbageTime" = excl_garbage_time
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -266,16 +267,17 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
 
   base_url <- "https://api.collegefootballdata.com/ppa/players/games?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&position=", position,
-    "&playerId=", athlete_id,
-    "&threshold=", threshold,
-    "&excludeGarbageTime=", excl_garbage_time
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "position" = position,
+    "playerId" = athlete_id,
+    "threshold" = threshold,
+    "excludeGarbageTime" = excl_garbage_time
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -338,7 +340,7 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
 #'   \item{`position`: character.}{Athlete Position.}
 #'   \item{`team`: character.}{Team name.}
 #'   \item{`conference`: character.}{Team conference.}
-#'   \item{`countable_plays`: integer.}{Number of plays which can be counted.}
+#'   \item{`countable_plays`: integer.}{DEPRECATED Number of plays which can be counted.}
 #'   \item{`avg_PPA_all`: double.}{Average overall predicted points added (PPA).}
 #'   \item{`avg_PPA_pass`: double.}{Average passing predicted points added (PPA).}
 #'   \item{`avg_PPA_rush`: double.}{Average rushing predicted points added (PPA).}
@@ -425,16 +427,17 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
 
   base_url <- "https://api.collegefootballdata.com/ppa/players/season?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&conference", conference,
-    "&position=", position,
-    "&playerId=", athlete_id,
-    "&threshold=", threshold,
-    "&excludeGarbageTime=", excl_garbage_time
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "conferenc" = conference,
+    "position" = position,
+    "playerId" = athlete_id,
+    "threshold" = threshold,
+    "excludeGarbageTime" = excl_garbage_time
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -463,7 +466,7 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
 
       df <- df %>%
         dplyr::rename("athlete_id" = "id") %>%
-        dplyr::arrange(-.data$countable_plays)
+        mutate(countable_plays = NA_integer_)
 
       df <- df %>%
         make_cfbfastR_data("Player season PPA data from CollegeFootballData.com",Sys.time())
@@ -517,11 +520,12 @@ cfbd_metrics_ppa_predicted <- function(down,
   }
   base_url <- "https://api.collegefootballdata.com/ppa/predicted?"
 
-  full_url <- paste0(
-    base_url,
-    "down=", down,
-    "&distance=", distance
+  query_params <- list(
+    "down" = down,
+    "distance" = distance
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -639,13 +643,14 @@ cfbd_metrics_ppa_teams <- function(year = NULL,
 
   base_url <- "https://api.collegefootballdata.com/ppa/teams?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&conference=", conference,
-    "&excludeGarbageTime=", excl_garbage_time
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "conference" = conference,
+    "excludeGarbageTime" = excl_garbage_time
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -745,13 +750,14 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
   }
   base_url <- "https://api.collegefootballdata.com/metrics/wp/pregame?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&seasonType=", season_type
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "seasonType" = season_type
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -779,6 +785,7 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON() %>%
         janitor::clean_names() %>%
+        dplyr::rename(home_win_prob = home_win_probability) %>%
         dplyr::mutate(away_win_prob = 1 - as.numeric(.data$home_win_prob)) %>%
         dplyr::select(all_of(cols))
 
@@ -847,10 +854,11 @@ cfbd_metrics_wp <- function(game_id) {
 
   base_url <- "https://api.collegefootballdata.com/metrics/wp?"
 
-  full_url <- paste0(
-    base_url,
-    "gameId=", game_id
+  query_params <- list(
+    "gameId" = game_id
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -879,6 +887,7 @@ cfbd_metrics_wp <- function(game_id) {
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON() %>%
         janitor::clean_names() %>%
+        dplyr::rename(home_win_prob = home_win_probability) %>%
         dplyr::mutate(away_win_prob = 1 - as.numeric(.data$home_win_prob)) %>%
         dplyr::select(all_of(cols))
 

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -147,7 +147,7 @@ cfbd_metrics_ppa_games <- function(year,
 #' @title
 #' **Get player game averages for predicted points added (PPA)**
 #' @param year (*Integer* required): Year, 4 digit format (*YYYY*).
-#' @param week (*Integer* optional): Week - values range from 1-15, 1-14 for seasons pre-playoff, i.e. 2013 or earlier. Required if team not provided
+#' @param week (*Integer* optional): Week - values range from 1-15, 1-14 for seasons pre-playoff, i.e. 2013 or earlier. Required if team not provided.
 #' @param team (*String* optional): D-I Team. Required if week not provided.
 #' @param position (*string* optional): Position abbreviation of the player you are searching for.
 #' Position Group  - options include:

--- a/R/cfbd_metrics.R
+++ b/R/cfbd_metrics.R
@@ -88,26 +88,18 @@ cfbd_metrics_ppa_games <- function(year,
                                    team = NULL,
                                    conference = NULL,
                                    excl_garbage_time = FALSE) {
-  args <- list(year = year)
 
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(week) && !is.numeric(week) && nchar(week) > 2) {
-    # Check if week is numeric, if not NULL
-    cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
-  if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
-    # Check if excl_garbage_time is TRUE, if not FALSE
-    cli::cli_abort("Enter valid excl_garbage_time value (Logical) - TRUE or FALSE")
-  }
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
+  validate_week(week)
+  validate_list(excl_garbage_time, c(T,F))
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ppa/games?"
-
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -115,23 +107,14 @@ cfbd_metrics_ppa_games <- function(year,
     "conference" = conference,
     "excludeGarbageTime" = excl_garbage_time
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content, flatten and return result as data.frame
@@ -209,47 +192,29 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
                                            threshold = NULL,
                                            excl_garbage_time = FALSE) {
 
-  # Position Group vector to check input arguments against
+  # Validation Lists ----
   pos_groups <- c(
     "QB", "RB", "FB", "TE", "WR", "OL", "OT", "G", "OC",
     "DB", "CB", "S", "LB", "DE", "NT", "DL", "DT",
     "K", "P", "PK", "LS"
   )
 
-  # Check if both year and team is null
-  if(is.null(year) & is.null(team)){
-    cli::cli_abort("Either year or team must be specified")
-  }
-  # Check if year is numeric
-  if(!is.null(year) && !is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(week) && !is.numeric(week) && nchar(week) > 2) {
-    # Check if week is numeric, if not NULL
-    cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
-  if (!is.null(position) && !(position %in% pos_groups)) {
-    ## check if position in position group set
-    cli::cli_abort("Enter valid position group\nOffense: QB, RB, FB, TE, WR,  OL, G, OT, C\nDefense: DB, CB, S, LB, DL, DE, DT, NT\nSpecial Teams: K, P, LS, PK")
-  }
-  if (!is.null(athlete_id) && !is.numeric(athlete_id)) {
-    # Check if athlete_id is numeric, if not NULL
-    cli::cli_abort("Enter valid athlete_id value (Integer)\nCan be found using the `cfbd_player_info()` function")
-  }
-  if (!is.null(threshold) && !is.numeric(threshold)) {
-    # Check if threshold is numeric, if not NULL
-    cli::cli_abort("Enter valid threshold value (Integer)")
-  }
-  if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
-    # Check if excl_garbage_time is TRUE, if not FALSE
-    cli::cli_abort("Enter valid excl_garbage_time value (Logical) - TRUE or FALSE")
-  }
 
+  # Validation ----
+  validate_api_key()
+  validate_reqs(year, team)
+  validate_year(year)
+  validate_week(week)
+  validate_list(position, pos_groups)
+  validate_id(athlete_id)
+  validate_id(threshold)
+  validate_list(excl_garbage_time, c(T,F))
+
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ppa/players/games?"
-
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -259,23 +224,14 @@ cfbd_metrics_ppa_players_games <- function(year = NULL,
     "threshold" = threshold,
     "excludeGarbageTime" = excl_garbage_time
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content, flatten and return result as data.frame
@@ -362,43 +318,27 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
                                             threshold = NULL,
                                             excl_garbage_time = FALSE) {
 
-  # Position Group vector to check input arguments against
+  # Validation Lists ----
   pos_groups <- c(
     "QB", "RB", "FB", "TE", "WR", "OL", "OT", "G", "OC",
     "DB", "CB", "S", "LB", "DE", "NT", "DL", "DT",
     "K", "P", "PK", "LS"
   )
-  # Check if both year and team is null
-  if(is.null(year) & is.null(team)){
-    cli::cli_abort("Either year or team must be specified")
-  }
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
 
-  if (!is.null(position) && !(position %in% pos_groups)) {
-    ## check if position in position group set
-    cli::cli_abort("Enter valid position group\nOffense: QB, RB, FB, TE, WR,  OL, G, OT, C\nDefense: DB, CB, S, LB, DL, DE, DT, NT\nSpecial Teams: K, P, LS, PK")
-  }
-  if (!is.null(athlete_id) && !is.numeric(athlete_id)) {
-    # Check if athlete_id is numeric, if not NULL
-    cli::cli_abort("Enter valid athlete_id value (Integer)\nCan be found using the `cfbd_player_info()` function")
-  }
-  if (!is.null(threshold) && !is.numeric(threshold)) {
-    # Check if threshold is numeric, if not NULL
-    cli::cli_abort("Enter valid threshold value (Integer)")
-  }
-  if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
-    # Check if excl_garbage_time is TRUE, if not FALSE
-    cli::cli_abort("Enter valid excl_garbage_time value (Logical) - TRUE or FALSE")
-  }
+  # Validation ----
+  validate_api_key()
+  validate_reqs(year, team)
+  validate_year(year)
+  validate_list(position, pos_groups)
+  validate_id(athlete_id)
+  validate_id(threshold)
+  validate_list(excl_garbage_time, c(T,F))
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ppa/players/season?"
-
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -408,23 +348,14 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
     "threshold" = threshold,
     "excludeGarbageTime" = excl_garbage_time
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content, flatten and return result as data.frame
@@ -482,38 +413,26 @@ cfbd_metrics_ppa_players_season <- function(year = NULL,
 
 cfbd_metrics_ppa_predicted <- function(down,
                                        distance) {
-  # Check if down is numeric
-  if(!is.numeric(down) && !(down <= 4)){
-    cli::cli_abort("Enter valid down (Integer): values from 1-4")
-  }
-  # Check if distance is numeric
-  if(!is.numeric(distance) && !(distance <= 99)){
-    cli::cli_abort("Enter valid distance (Integer): values from 1-99")
-  }
-  base_url <- "https://api.collegefootballdata.com/ppa/predicted?"
 
+  # Validation ----
+  validate_api_key()
+  validate_range(down, 1, 4)
+  validate_range(distance, 1, 99)
+
+  # Query API ----
+  base_url <- "https://api.collegefootballdata.com/ppa/predicted?"
   query_params <- list(
     "down" = down,
     "distance" = distance
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content, flatten and return result as data.frame
@@ -586,47 +505,32 @@ cfbd_metrics_ppa_teams <- function(year = NULL,
                                    team = NULL,
                                    conference = NULL,
                                    excl_garbage_time = FALSE) {
-  # Check if both year and team is null
-  if(is.null(year) & is.null(team)){
-    cli::cli_abort("Either year or team must be specified")
-  }
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
-  if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
-    # Check if excl_garbage_time is TRUE, if not FALSE
-    cli::cli_abort("Enter valid excl_garbage_time value (Logical) - TRUE or FALSE")
-  }
 
+  # Validation ----
+  validate_api_key()
+  validate_reqs(year, team)
+  validate_year(year)
+  validate_list(excl_garbage_time, c(T,F))
+
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ppa/teams?"
-
   query_params <- list(
     "year" = year,
     "team" = team,
     "conference" = conference,
     "excludeGarbageTime" = excl_garbage_time
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content, flatten and return result as data.frame
@@ -688,35 +592,25 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
                                     week = NULL,
                                     team = NULL,
                                     season_type = "regular") {
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(week) && !is.numeric(week) && nchar(week) > 2) {
-    # Check if week is numeric, if not NULL
-    cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
 
-  if (!(season_type %in% c("postseason", "regular"))) {
-    # Check if season_type is appropriate, if not NULL
-    cli::cli_abort("Enter valid season_type (String): regular or postseason")
-  }
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
+  validate_week(week)
+  validate_season_type(season_type)
+
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/metrics/wp/pregame?"
-
   query_params <- list(
     "year" = year,
     "week" = week,
     "team" = team,
     "seasonType" = season_type
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   cols <- c(
     "season", "season_type", "week", "game_id",
@@ -728,12 +622,7 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame
@@ -798,26 +687,16 @@ cfbd_metrics_wp_pregame <- function(year = NULL,
 
 cfbd_metrics_wp <- function(game_id) {
 
+  # Validation ----
+  validate_api_key()
+  validate_game_id(game_id)
 
-
-  # Check if game_id is numeric, if not NULL
-
-  if (!is.null(game_id) && !is.numeric(game_id)) {
-    # Check if game_id is numeric, if not NULL
-    cli::cli_abort("Enter valid game_id (numeric value)")
-  }
-
-
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/metrics/wp?"
-
   query_params <- list(
     "gameId" = game_id
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   cols <- c(
     "play_id", "play_text", "home_id", "home", "away_id", "away",
@@ -830,12 +709,7 @@ cfbd_metrics_wp <- function(game_id) {
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame

--- a/R/cfbd_pbp_data.R
+++ b/R/cfbd_pbp_data.R
@@ -371,7 +371,6 @@
 #' @importFrom glue glue
 #' @importFrom dplyr mutate left_join select rename filter group_by arrange ungroup setdiff
 #' @importFrom jsonlite fromJSON
-#' @importFrom utils URLencode
 #' @importFrom utils globalVariables
 #' @importFrom cli cli_abort
 #' @export
@@ -399,12 +398,7 @@ cfbd_pbp_data <- function(year,
     cli::cli_abort("Enter valid season_type: regular, postseason, or both")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
 
   if (!is.null(play_type)) {

--- a/R/cfbd_pbp_data.R
+++ b/R/cfbd_pbp_data.R
@@ -427,14 +427,15 @@ cfbd_pbp_data <- function(year,
 
   ## Inputs
   ## Year, Week, Team
-  full_url <- paste0(
-    play_base_url,
-    "seasonType=", season_type,
-    "&year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&playType=", pt_id
+  query_params <- list(
+    "seasonType" = season_type,
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "playType" = pt_id
   )
+
+  full_url <- httr::modify_url(play_base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -474,7 +475,7 @@ cfbd_pbp_data <- function(year,
           dplyr::select("game_id", "spread", "formatted_spread", "over_under")
 
         raw_play_df <- raw_play_df %>%
-          dplyr::left_join(game_spread, by = c("game_id"))
+          dplyr::left_join(game_spread, by = c("gameId" = "game_id"))
       },
       error = function(e) {
       },
@@ -490,6 +491,7 @@ cfbd_pbp_data <- function(year,
   colnames(clean_drive_df) <- paste0("drive_", colnames(clean_drive_df))
 
   play_df <- raw_play_df %>%
+    janitor::clean_names() %>%
     dplyr::mutate(drive_id = as.numeric(.data$drive_id)) %>%
     dplyr::left_join(clean_drive_df,
       by = c(

--- a/R/cfbd_pbp_data.R
+++ b/R/cfbd_pbp_data.R
@@ -416,7 +416,7 @@ cfbd_pbp_data <- function(year,
   team <- handle_accents(team)
 
   # Query API ----
-  play_base_url <- "https://api.collegefootballdata.com/plays?"
+  play_base_url <- "https://api.collegefootballdata.com/plays"
   query_params <- list(
     "seasonType" = season_type,
     "year" = year,

--- a/R/cfbd_play.R
+++ b/R/cfbd_play.R
@@ -172,19 +172,20 @@ cfbd_plays <- function(year = 2020,
 
 
   base_url <- "https://api.collegefootballdata.com/plays?"
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&offense=", offense,
-    "&defense=", defense,
-    "&offenseConference=", offense_conference,
-    "&defenseConference=", defense_conference,
-    "&seasonType=", season_type,
-    "&playType=", play_type,
-    "&classification=", division
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "offense" = offense,
+    "defense" = defense,
+    "offenseConference" = offense_conference,
+    "defenseConference" = defense_conference,
+    "seasonType" = season_type,
+    "playType" = play_type,
+    "classification" = division
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -206,7 +207,8 @@ cfbd_plays <- function(year = 2020,
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON(flatten = TRUE) %>%
-        dplyr::rename("play_id" = "id")
+        dplyr::rename("play_id" = "id") %>%
+        janitor::clean_names()
 
 
       df <- df %>%
@@ -346,18 +348,19 @@ cfbd_play_stats_player <- function(year = NULL,
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
   }
 
-  base_url <- "https://api.collegefootballdata.com/play/stats?"
+  base_url <- "https://api.collegefootballdata.com/plays/stats?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&gameId=", game_id,
-    "&athleteID=", athlete_id,
-    "&statTypeId=", stat_type_id,
-    "&seasonType=", season_type
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "gameId" = game_id,
+    "athleteID" = athlete_id,
+    "statTypeId" = stat_type_id,
+    "seasonType" = season_type
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -575,7 +578,7 @@ cfbd_play_stats_player <- function(year = NULL,
 #'   try(cfbd_play_stats_types())
 #' }
 cfbd_play_stats_types <- function() {
-  full_url <- "https://api.collegefootballdata.com/play/stat/types"
+  full_url <- "https://api.collegefootballdata.com/plays/stats/types"
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -632,7 +635,7 @@ cfbd_play_stats_types <- function() {
 #'   try(cfbd_play_types())
 #' }
 cfbd_play_types <- function() {
-  full_url <- "https://api.collegefootballdata.com/play/types"
+  full_url <- "https://api.collegefootballdata.com/plays/types"
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)

--- a/R/cfbd_play.R
+++ b/R/cfbd_play.R
@@ -102,7 +102,6 @@ NULL
 #' }
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export
@@ -130,44 +129,17 @@ cfbd_plays <- function(year = 2020,
     cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(offense)) {
-    if (offense == "San Jose State") {
-      offense <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode offense parameter for URL if not NULL
-      offense <- utils::URLencode(offense, reserved = TRUE)
-    }
+    offense <- handle_accents(offense)
   }
   if (!is.null(defense)) {
-    if (defense == "San Jose State") {
-      defense <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode defense parameter for URL if not NULL
-      defense <- utils::URLencode(defense, reserved = TRUE)
-    }
-  }
-  if (!is.null(offense_conference)) {
-    # Encode offense_conference parameter for URL if not NULL
-    offense_conference <- utils::URLencode(offense_conference, reserved = TRUE)
-  }
-  if (!is.null(defense_conference)) {
-    # Encode defense_conference parameter for URL if not NULL
-    defense_conference <- utils::URLencode(defense_conference, reserved = TRUE)
+    defense <- handle_accents(defense)
   }
   if (!(season_type %in% c("postseason", "regular", "both"))) {
     # Check if season_type is appropriate, if not NULL
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
-  }
-  if (!is.null(division)) {
-    # # Check division parameter
-    division <- utils::URLencode(division, reserved = TRUE)
   }
 
 
@@ -296,7 +268,6 @@ cfbd_plays <- function(year = 2020,
 #' @keywords Player PBP
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @import dplyr
 #' @import tidyr
@@ -323,12 +294,7 @@ cfbd_play_stats_player <- function(year = NULL,
     cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(game_id) && !is.numeric(game_id)) {
     # Check if game_id is numeric, if not NULL
@@ -626,7 +592,6 @@ cfbd_play_stats_types <- function() {
 #' }
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export

--- a/R/cfbd_play.R
+++ b/R/cfbd_play.R
@@ -133,7 +133,7 @@ cfbd_plays <- function(year = 2020,
   defense <- handle_accents(defense)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/plays?"
+  base_url <- "https://api.collegefootballdata.com/plays"
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -279,7 +279,7 @@ cfbd_play_stats_player <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/plays/stats?"
+  base_url <- "https://api.collegefootballdata.com/plays/stats"
   query_params <- list(
     "year" = year,
     "week" = week,

--- a/R/cfbd_players.R
+++ b/R/cfbd_players.R
@@ -102,13 +102,14 @@ cfbd_player_info <- function(search_term,
   base_url <- "https://api.collegefootballdata.com/player/search?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "searchTerm=", search_term,
-    "&position=", position,
-    "&team=", team,
-    "&year=", year
+  query_params <- list(
+    "searchTerm" = search_term,
+    "position" = position,
+    "team" = team,
+    "year" = year
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -152,7 +153,7 @@ cfbd_player_info <- function(search_term,
 
 #' @title
 #' **Get player returning production**
-#' @param year (*Integer* required, default 2019): Year, 4 digit format (*YYYY*).
+#' @param year (*Integer* required, default most recent season): Year, 4 digit format (*YYYY*).
 #' @param team (*String* optional): Team - Select a valid team, D1 football
 #' @param conference (*String* optional): Conference abbreviation - Select a valid FBS conference
 #' Conference abbreviations P5: ACC, B12, B1G, SEC, PAC
@@ -188,7 +189,7 @@ cfbd_player_info <- function(search_term,
 #'    try(cfbd_player_returning(year = 2019, team = "Florida State"))
 #' }
 #'
-cfbd_player_returning <- function(year = 2019,
+cfbd_player_returning <- function(year = most_recent_cfb_season(),
                                   team = NULL,
                                   conference = NULL) {
 
@@ -213,12 +214,13 @@ cfbd_player_returning <- function(year = 2019,
   base_url <- "https://api.collegefootballdata.com/player/returning?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -268,7 +270,7 @@ cfbd_player_returning <- function(year = 2019,
 
 #' @title
 #' **Get player usage metrics**
-#' @param year (*Integer* required, default 2019): Year, 4 digit format (*YYYY*).
+#' @param year (*Integer* required, default most recent season): Year, 4 digit format (*YYYY*).
 #' @param team (*String* optional): Team - Select a valid team, D1 football
 #' @param conference (*String* optional): Conference abbreviation - Select a valid FBS conference
 #' Conference abbreviations P5: ACC, B12, B1G, SEC, PAC
@@ -312,7 +314,7 @@ cfbd_player_returning <- function(year = 2019,
 #'   try(cfbd_player_usage(year = 2019, position = "WR", team = "Florida State"))
 #' }
 #'
-cfbd_player_usage <- function(year = 2019,
+cfbd_player_usage <- function(year = most_recent_cfb_season(),
                               team = NULL,
                               conference = NULL,
                               position = NULL,
@@ -358,15 +360,16 @@ cfbd_player_usage <- function(year = 2019,
   base_url <- "https://api.collegefootballdata.com/player/usage?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&conference=", conference,
-    "&position=", position,
-    "&athleteID=", athlete_id,
-    "&excludeGarbageTime=", excl_garbage_time
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "conference" = conference,
+    "position" = position,
+    "athleteID" = athlete_id,
+    "excludeGarbageTime" = excl_garbage_time
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)

--- a/R/cfbd_players.R
+++ b/R/cfbd_players.R
@@ -54,7 +54,6 @@ NULL
 #' @keywords Players
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -72,9 +71,6 @@ cfbd_player_info <- function(search_term,
                              team = NULL,
                              year = NULL) {
 
-  # Encode search_term parameter for URL
-  search_term <- utils::URLencode(search_term, reserved = TRUE)
-
   # Position Group vector to check input arguments against
   pos_groups <- c(
     "QB", "RB", "FB", "TE", "WR", "OL", "OT", "G", "OC",
@@ -87,12 +83,7 @@ cfbd_player_info <- function(search_term,
     cli::cli_abort("Enter valid position group\nOffense: QB, RB, FB, TE, WR,  OL, G, OT, C\nDefense: DB, CB, S, LB, DL, DE, DT, NT\nSpecial Teams: K, P, LS, PK")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
 
   # Check if year is numeric
@@ -179,7 +170,6 @@ cfbd_player_info <- function(search_term,
 #' @keywords Returning Production
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom dplyr rename
@@ -198,17 +188,7 @@ cfbd_player_returning <- function(year = most_recent_cfb_season(),
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/player/returning?"
@@ -303,7 +283,6 @@ cfbd_player_returning <- function(year = most_recent_cfb_season(),
 #' @keywords Player Usage
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom purrr map_if
@@ -332,17 +311,7 @@ cfbd_player_usage <- function(year = most_recent_cfb_season(),
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
   if (!is.null(position)&&!(position %in% pos_groups)) {
     ## check if position in position group set

--- a/R/cfbd_players.R
+++ b/R/cfbd_players.R
@@ -87,7 +87,7 @@ cfbd_player_info <- function(search_term,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/player/search?"
+  base_url <- "https://api.collegefootballdata.com/player/search"
   query_params <- list(
     "searchTerm" = search_term,
     "position" = position,
@@ -178,7 +178,7 @@ cfbd_player_returning <- function(year = most_recent_cfb_season(),
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/player/returning?"
+  base_url <- "https://api.collegefootballdata.com/player/returning"
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -294,7 +294,7 @@ cfbd_player_usage <- function(year = most_recent_cfb_season(),
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/player/usage?"
+  base_url <- "https://api.collegefootballdata.com/player/usage"
   query_params <- list(
     "year" = year,
     "team" = team,

--- a/R/cfbd_ratings.R
+++ b/R/cfbd_ratings.R
@@ -89,44 +89,29 @@ NULL
 #' }
 #'
 cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(week) && !is.numeric(week) && nchar(week) > 2) {
-    # Check if week is numeric, if not NULL
-    cli::cli_abort("Enter valid week 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)")
-  }
-  if (!(season_type %in% c("postseason", "regular"))) {
-    # Check if season_type is appropriate, if not NULL
-    cli::cli_abort("Enter valid season_type (String): regular or postseason")
-  }
 
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
+  validate_week(week)
+  validate_season_type(season_type, allow_both = F)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/rankings?"
-
   query_params <- list(
     "year" = year,
     "week" = week,
     "seasonType" = season_type
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
-  # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
-  check_status(res)
 
   polls <- data.frame()
   tryCatch(
     expr = {
+      # Create the GET request and set response as res
+      res <- get_req(full_url)
+      check_status(res)
+
       polls <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON(flatten = TRUE) %>%
@@ -213,41 +198,29 @@ cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
 #'
 cfbd_ratings_sp <- function(year = NULL, team = NULL) {
 
-  if(is.null(year) && is.null(team)){
-    cli::cli_abort( "Must provide either team or year" )
-  }
-  # Check if year is numeric
-  if(!is.null(year) && !is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
+  # Validation ----
+  validate_reqs(year, team)
+  validate_year(year)
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ratings/sp?"
-
   query_params <- list(
     "year" = year,
     "team" = team
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
-  # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
-  check_status(res)
 
   df <- data.frame()
   tryCatch(
     expr = {
+
+      # Create the GET request and set response as res
+      res <- get_req(full_url)
+      check_status(res)
+
       # Get the content and return it as data.frame
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
@@ -345,34 +318,26 @@ cfbd_ratings_sp <- function(year = NULL, team = NULL) {
 #'
 cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
 
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  base_url <- "https://api.collegefootballdata.com/ratings/sp/conferences?"
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
 
+  # Query API ----
+  base_url <- "https://api.collegefootballdata.com/ratings/sp/conferences?"
   query_params <- list(
     "year" = year,
     "conference" = conference
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
-  # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
-  check_status(res)
 
   df <- data.frame()
   tryCatch(
     expr = {
+
+      # Create the GET request and set response as res
+      res <- get_req(full_url)
+      check_status(res)
+
       # Get the content and return it as data.frame
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
@@ -451,42 +416,31 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
 #'
 cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
 
-  if(is.null(year) && is.null(team)){
-    cli::cli_abort( "Must provide either team or year" )
-  }
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
+  # Validation ----
+  validate_api_key()
+  validate_reqs(year, team)
+  validate_year(year)
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ratings/srs?"
-
   query_params <- list(
     "year" = year,
     "team" = team,
     "conference" = conference
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
-  # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
-  check_status(res)
 
   df <- data.frame()
   tryCatch(
     expr = {
+
+      # Create the GET request and set response as res
+      res <- get_req(full_url)
+      check_status(res)
+
       # Get the content and return it as data.frame
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
@@ -547,44 +501,32 @@ cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
 #'
 cfbd_ratings_elo <- function(year = NULL, week = NULL, team = NULL, conference = NULL) {
 
-  # Check if year is numeric
-  if(!is.null(year) && !is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  # Check if year is numeric
-  if(!is.null(week) && !is.numeric(week) && nchar(week) > 2){
-    cli::cli_abort("Enter valid week as a number")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
+  validate_week(week)
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/ratings/elo?"
-
   query_params <- list(
     "year" = year,
     "week" = week,
     "team" = team,
     "conference" = conference
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
-  # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
-  check_status(res)
 
   df <- data.frame()
   tryCatch(
     expr = {
+
+      # Create the GET request and set response as res
+      res <- get_req(full_url)
+      check_status(res)
+
       # Get the content and return it as data.frame
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%

--- a/R/cfbd_ratings.R
+++ b/R/cfbd_ratings.R
@@ -97,7 +97,7 @@ cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
   validate_season_type(season_type, allow_both = F)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/rankings?"
+  base_url <- "https://api.collegefootballdata.com/rankings"
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -206,7 +206,7 @@ cfbd_ratings_sp <- function(year = NULL, team = NULL) {
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ratings/sp?"
+  base_url <- "https://api.collegefootballdata.com/ratings/sp"
   query_params <- list(
     "year" = year,
     "team" = team
@@ -323,7 +323,7 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
   validate_year(year)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ratings/sp/conferences?"
+  base_url <- "https://api.collegefootballdata.com/ratings/sp/conferences"
   query_params <- list(
     "year" = year,
     "conference" = conference
@@ -425,7 +425,7 @@ cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ratings/srs?"
+  base_url <- "https://api.collegefootballdata.com/ratings/srs"
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -510,7 +510,7 @@ cfbd_ratings_elo <- function(year = NULL, week = NULL, team = NULL, conference =
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/ratings/elo?"
+  base_url <- "https://api.collegefootballdata.com/ratings/elo"
   query_params <- list(
     "year" = year,
     "week" = week,

--- a/R/cfbd_ratings.R
+++ b/R/cfbd_ratings.R
@@ -104,12 +104,13 @@ cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
 
   base_url <- "https://api.collegefootballdata.com/rankings?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&seasonType=", season_type
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "seasonType" = season_type
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -213,6 +214,9 @@ cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
 #'
 cfbd_ratings_sp <- function(year = NULL, team = NULL) {
 
+  if(is.null(year) && is.null(team)){
+    cli::cli_abort( "Must provide either team or year" )
+  }
   # Check if year is numeric
   if(!is.null(year) && !is.numeric(year) && nchar(year) != 4){
     cli::cli_abort("Enter valid year as a number (YYYY)")
@@ -226,12 +230,14 @@ cfbd_ratings_sp <- function(year = NULL, team = NULL) {
     }
   }
 
-  base_url <- "https://api.collegefootballdata.com/ratings/sp"
-  full_url <- paste0(
-    base_url,
-    "?year=", year,
-    "&team=", team
+  base_url <- "https://api.collegefootballdata.com/ratings/sp?"
+
+  query_params <- list(
+    "year" = year,
+    "team" = team
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -357,11 +363,12 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
   }
   base_url <- "https://api.collegefootballdata.com/ratings/sp/conferences?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -457,6 +464,9 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
 #'
 cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
 
+  if(is.null(year) && is.null(team)){
+    cli::cli_abort( "Must provide either team or year" )
+  }
   # Check if year is numeric
   if(!is.numeric(year) && nchar(year) != 4){
     cli::cli_abort("Enter valid year as a number (YYYY)")
@@ -477,12 +487,13 @@ cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
 
   base_url <- "https://api.collegefootballdata.com/ratings/srs?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -584,13 +595,14 @@ cfbd_ratings_elo <- function(year = NULL, week = NULL, team = NULL, conference =
 
   base_url <- "https://api.collegefootballdata.com/ratings/elo?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)

--- a/R/cfbd_ratings.R
+++ b/R/cfbd_ratings.R
@@ -145,8 +145,8 @@ cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
 #' @description
 #' At least one of **year** or **team** must be specified for the function to run
 #'
-#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*)
-#' @param team (*String* optional): D-I Team
+#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*). Required if year not provided
+#' @param team (*String* optional): D-I Team. Required if year not provided
 #'
 #' @return [cfbd_ratings_sp()] - A data frame with 26 variables:
 #' \describe{
@@ -386,8 +386,8 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
 #' @description
 #' At least one of **year** or **team** must be specified for the function to run
 #'
-#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*)
-#' @param team (*String* optional): D-I Team
+#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*). Required if team not provided
+#' @param team (*String* optional): D-I Team. Required if year not provided
 #' @param conference (*String* optional): Conference abbreviation - SRS information by conference
 #' Conference abbreviations P5: ACC, B12, B1G, SEC, PAC
 #' Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC

--- a/R/cfbd_ratings.R
+++ b/R/cfbd_ratings.R
@@ -198,7 +198,6 @@ cfbd_rankings <- function(year, week = NULL, season_type = "regular") {
 #' @keywords SP+
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom dplyr rename
@@ -222,12 +221,7 @@ cfbd_ratings_sp <- function(year = NULL, team = NULL) {
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/ratings/sp?"
@@ -336,7 +330,6 @@ cfbd_ratings_sp <- function(year = NULL, team = NULL) {
 #' @keywords SP+
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom dplyr rename
@@ -355,11 +348,6 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
   # Check if year is numeric
   if(!is.numeric(year) && nchar(year) != 4){
     cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
   }
   base_url <- "https://api.collegefootballdata.com/ratings/sp/conferences?"
 
@@ -452,7 +440,6 @@ cfbd_ratings_sp_conference <- function(year = NULL, conference = NULL) {
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
 #' @importFrom cli cli_abort
-#' @importFrom utils URLencode
 #' @importFrom glue glue
 #' @export
 #' @examples
@@ -472,17 +459,7 @@ cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/ratings/srs?"
@@ -559,7 +536,6 @@ cfbd_ratings_srs <- function(year = NULL, team = NULL, conference = NULL) {
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
 #' @importFrom cli cli_abort
-#' @importFrom utils URLencode
 #' @importFrom glue glue
 #' @export
 #' @examples
@@ -580,17 +556,7 @@ cfbd_ratings_elo <- function(year = NULL, week = NULL, team = NULL, conference =
     cli::cli_abort("Enter valid week as a number")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/ratings/elo?"

--- a/R/cfbd_recruiting.R
+++ b/R/cfbd_recruiting.R
@@ -95,7 +95,6 @@ NULL
 #' @keywords Recruiting
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom janitor clean_names
@@ -129,12 +128,7 @@ cfbd_recruiting_player <- function(year = NULL,
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!(recruit_type %in% c("HighSchool","PrepSchool", "JUCO"))) {
     # Check if recruit_type is appropriate, if not HighSchool
@@ -220,7 +214,6 @@ cfbd_recruiting_player <- function(year = NULL,
 #' @keywords Recruiting
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom dplyr rename
@@ -243,17 +236,7 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
     cli::cli_abort("Enter valid end_year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/recruiting/groups?"
@@ -323,7 +306,6 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
 #' @keywords Recruiting
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export
@@ -349,12 +331,7 @@ cfbd_recruiting_team <- function(year = NULL,
     cli::cli_abort("Enter valid year as a number (YYYY)")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
 
   base_url <- "https://api.collegefootballdata.com/recruiting/teams?"
@@ -420,7 +397,6 @@ cfbd_recruiting_team <- function(year = NULL,
 #' @keywords Recruiting
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET RETRY
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue

--- a/R/cfbd_recruiting.R
+++ b/R/cfbd_recruiting.R
@@ -114,38 +114,25 @@ cfbd_recruiting_player <- function(year = NULL,
                                    state = NULL,
                                    position = NULL) {
 
-  # Position Group vector to check arguments against
+  # Validation Lists ----
   pos_groups <- c(
     "PRO", "DUAL", "RB", "FB", "TE", "OT", "OG", "OC", "WR",
     "CB", "S", "OLB", "ILB", "WDE", "SDE", "DT", "K", "P"
   )
 
-  if(is.null(year) && is.null(team)){
-    cli::cli_abort( "Must provide either team or year" )
-  }
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
-  if (!(recruit_type %in% c("HighSchool","PrepSchool", "JUCO"))) {
-    # Check if recruit_type is appropriate, if not HighSchool
-    cli::cli_abort("Enter valid recruit_type (String): HighSchool, PrepSchool, or JUCO")
-  }
-  if (!is.null(state) && nchar(state) != 2) {
-    ## check if state is length 2
-    cli::cli_abort("Enter valid 2-letter State abbreviation")
-  }
-  if (!is.null(position) && !(position %in% pos_groups)) {
-    ## check if position in position group set
-    cli::cli_abort("Enter valid position group \nOffense: PRO, DUAL, RB, FB, TE, OT, OG, OC, WR\nDefense: CB, S, OLB, ILB, WDE, SDE, DT\nSpecial Teams: K, P")
-  }
+  # Validation ----
+  validate_api_key()
+  validate_reqs(year, team)
+  validate_year(year)
+  validate_list(recruit_type, c("HighSchool","PrepSchool", "JUCO"))
+  validate_list(state, state.abb)
+  validate_list(position, pos_groups)
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/recruiting/players?"
-
-  # Create full url using base and input arguments
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -153,23 +140,14 @@ cfbd_recruiting_player <- function(year = NULL,
     "position" = position,
     "state" = state
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame
@@ -229,42 +207,31 @@ cfbd_recruiting_player <- function(year = NULL,
 #'
 cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
                                      team = NULL, conference = NULL) {
-  if(!is.null(start_year)&& !is.numeric(start_year) && nchar(start_year) != 4){
-    cli::cli_abort("Enter valid start_year as a number (YYYY)")
-  }
-  if(!is.null(end_year)&& !is.numeric(end_year) && nchar(end_year) != 4){
-    cli::cli_abort("Enter valid end_year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
 
+  # Validation ----
+  validate_api_key()
+  validate_year(start_year)
+  validate_year(end_year)
+
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/recruiting/groups?"
-
-  # Create full url using base and input arguments
   query_params <- list(
     "startYear" = start_year,
     "endYear" = end_year,
     "team" = team,
     "conference" = conference
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame
@@ -323,42 +290,30 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
 cfbd_recruiting_team <- function(year = NULL,
                                  team = NULL) {
 
-  if(is.null(year) && is.null(team)){
-    cli::cli_abort( "Must provide either team or year" )
-  }
-  # Check if year is numeric
-  if(!is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  if (!is.null(team)) {
-    team <- handle_accents(team)
-  }
+  # Validation ----
+  validate_api_key()
+  validate_reqs(year, team)
+  validate_year(year)
 
+  # Team Name Handling ----
+  team <- handle_accents(team)
+
+  # Query API ----
   base_url <- "https://api.collegefootballdata.com/recruiting/teams?"
-
-  # Create full url using base and input arguments
   query_params <- list(
     "year" = year,
     "team" = team
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
-  # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
-  check_status(res)
 
   df <- data.frame()
   tryCatch(
     expr = {
+
+      # Create the GET request and set response as res
+      res <- get_req(full_url)
+      check_status(res)
+
       # Get the content and return it as data.frame
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
@@ -409,33 +364,23 @@ cfbd_recruiting_team <- function(year = NULL,
 #' }
 cfbd_recruiting_transfer_portal <- function(year) {
 
-  # Check if year is numeric
-  if(!is.null(year) && !is.numeric(year) && nchar(year) != 4){
-    cli::cli_abort("Enter valid year as a number (YYYY)")
-  }
-  base_url <- "https://api.collegefootballdata.com/player/portal?"
+  # Validation ----
+  validate_api_key()
+  validate_year(year)
 
-  # Create full url using base and input arguments
+  # Query API ----
+  base_url <- "https://api.collegefootballdata.com/player/portal?"
   query_params <- list(
     "year" = year
   )
-
   full_url <- httr::modify_url(base_url, query=query_params)
-
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
 
   df <- data.frame()
   tryCatch(
     expr = {
 
       # Create the GET request and set response as res
-      res <- httr::RETRY(
-        "GET", full_url,
-        httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-      )
-
-      # Check the result
+      res <- get_req(full_url)
       check_status(res)
 
       # Get the content and return it as data.frame

--- a/R/cfbd_recruiting.R
+++ b/R/cfbd_recruiting.R
@@ -133,7 +133,7 @@ cfbd_recruiting_player <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/recruiting/players?"
+  base_url <- "https://api.collegefootballdata.com/recruiting/players"
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -218,7 +218,7 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/recruiting/groups?"
+  base_url <- "https://api.collegefootballdata.com/recruiting/groups"
   query_params <- list(
     "startYear" = start_year,
     "endYear" = end_year,
@@ -301,7 +301,7 @@ cfbd_recruiting_team <- function(year = NULL,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/recruiting/teams?"
+  base_url <- "https://api.collegefootballdata.com/recruiting/teams"
   query_params <- list(
     "year" = year,
     "team" = team
@@ -371,7 +371,7 @@ cfbd_recruiting_transfer_portal <- function(year) {
   validate_year(year)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/player/portal?"
+  base_url <- "https://api.collegefootballdata.com/player/portal"
   query_params <- list(
     "year" = year
   )

--- a/R/cfbd_recruiting.R
+++ b/R/cfbd_recruiting.R
@@ -120,6 +120,10 @@ cfbd_recruiting_player <- function(year = NULL,
     "PRO", "DUAL", "RB", "FB", "TE", "OT", "OG", "OC", "WR",
     "CB", "S", "OLB", "ILB", "WDE", "SDE", "DT", "K", "P"
   )
+
+  if(is.null(year) && is.null(team)){
+    cli::cli_abort( "Must provide either team or year" )
+  }
   # Check if year is numeric
   if(!is.numeric(year) && nchar(year) != 4){
     cli::cli_abort("Enter valid year as a number (YYYY)")
@@ -148,14 +152,15 @@ cfbd_recruiting_player <- function(year = NULL,
   base_url <- "https://api.collegefootballdata.com/recruiting/players?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&classification=", recruit_type,
-    "&position=", position,
-    "&state=", state
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "classification" = recruit_type,
+    "position" = position,
+    "state" = state
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -254,17 +259,14 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
   base_url <- "https://api.collegefootballdata.com/recruiting/groups?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "startYear=",
-    start_year,
-    "&endYear=",
-    end_year,
-    "&team=",
-    team,
-    "&conference=",
-    conference
+  query_params <- list(
+    "startYear" = start_year,
+    "endYear" = end_year,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -339,6 +341,9 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
 cfbd_recruiting_team <- function(year = NULL,
                                  team = NULL) {
 
+  if(is.null(year) && is.null(team)){
+    cli::cli_abort( "Must provide either team or year" )
+  }
   # Check if year is numeric
   if(!is.numeric(year) && nchar(year) != 4){
     cli::cli_abort("Enter valid year as a number (YYYY)")
@@ -355,11 +360,12 @@ cfbd_recruiting_team <- function(year = NULL,
   base_url <- "https://api.collegefootballdata.com/recruiting/teams?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team
+  query_params <- list(
+    "year" = year,
+    "team" = team
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -434,10 +440,11 @@ cfbd_recruiting_transfer_portal <- function(year) {
   base_url <- "https://api.collegefootballdata.com/player/portal?"
 
   # Create full url using base and input arguments
-  full_url <- paste0(
-    base_url,
-    "year=", year
+  query_params <- list(
+    "year" = year
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)

--- a/R/cfbd_recruiting.R
+++ b/R/cfbd_recruiting.R
@@ -60,8 +60,8 @@
 NULL
 #' @title
 #' **Get player recruiting rankings**
-#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*) - Minimum: 2000, Maximum: 2020 currently
-#' @param team (*String* optional): D-I Team
+#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*) - Minimum: 2000. Required if team not provided
+#' @param team (*String* optional): D-I Team. Required if year not provided
 #' @param recruit_type (*String* optional): default API return is 'HighSchool', other options include 'JUCO'
 #' or 'PrepSchool'  - For position group information
 #' @param state (*String* optional): Two letter State abbreviation
@@ -124,6 +124,7 @@ cfbd_recruiting_player <- function(year = NULL,
   validate_api_key()
   validate_reqs(year, team)
   validate_year(year)
+  validate_range(year, 2000)
   validate_list(recruit_type, c("HighSchool","PrepSchool", "JUCO"))
   validate_list(state, state.abb)
   validate_list(position, pos_groups)
@@ -260,8 +261,8 @@ cfbd_recruiting_position <- function(start_year = NULL, end_year = NULL,
 
 #' @title
 #' **Get college football recruiting team rankings information.**
-#' @param year (*Integer* optional): Recruiting Class Year, 4 digit format (*YYYY*). *Note: 2000 is the minimum value*
-#' @param team (*String* optional): Team - Select a valid team, D1 football
+#' @param year (*Integer* optional): Recruiting Class Year, 4 digit format (*YYYY*) - Minimum: 2000. Required if team not provided.
+#' @param team (*String* optional): Team - Select a valid team, D1 football. Required if year not provided.
 #'
 #' @return [cfbd_recruiting_team()] - A data frame with 4 variables:
 #' \describe{
@@ -294,6 +295,7 @@ cfbd_recruiting_team <- function(year = NULL,
   validate_api_key()
   validate_reqs(year, team)
   validate_year(year)
+  validate_range(year, 2000)
 
   # Team Name Handling ----
   team <- handle_accents(team)

--- a/R/cfbd_stats.R
+++ b/R/cfbd_stats.R
@@ -182,7 +182,7 @@ cfbd_stats_categories <- function() {
 #' @keywords Game Advanced Stats
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export
@@ -211,16 +211,11 @@ cfbd_stats_game_advanced <- function(year,
   }
 
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (!is.null(opponent)) {
     # Encode opponent parameter for URL, if not NULL
-    opponent <- utils::URLencode(opponent, reserved = TRUE)
+    opponent <- handle_accents(opponent)
   }
   if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
     # Check if excl_garbage_time is TRUE, if not FALSE
@@ -406,7 +401,7 @@ cfbd_stats_game_advanced <- function(year,
 #' @keywords Team Season Advanced Stats
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export
@@ -426,12 +421,7 @@ cfbd_stats_season_advanced <- function(year,
   }
 
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   if (excl_garbage_time != FALSE && excl_garbage_time!=TRUE) {
     # Check if excl_garbage_time is TRUE, if not FALSE
@@ -604,7 +594,7 @@ cfbd_stats_season_advanced <- function(year,
 #' @keywords Player Season Stats
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -643,17 +633,7 @@ cfbd_stats_season_player <- function(year,
     cli::cli_abort("Enter valid season_type (String): regular, postseason, or both")
   }
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      # team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   if (!is.null(start_week) && !is.numeric(start_week) && nchar(start_week) > 2) {
@@ -672,8 +652,6 @@ cfbd_stats_season_player <- function(year,
       # Check category parameter in category if not NULL
       cli::cli_abort("Incorrect category, potential misspelling.\nOffense: passing, receiving, rushing\nDefense: defensive, fumbles, interceptions\nSpecial Teams: punting, puntReturns, kicking, kickReturns")
     }
-    # Encode conference parameter for URL, if not NULL
-    category <- utils::URLencode(category, reserved = TRUE)
   }
 
 
@@ -859,7 +837,7 @@ cfbd_stats_season_player <- function(year,
 #' @keywords Team Season Stats
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode URLdecode
+#' @importFrom utils URLdecode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom dplyr select mutate rename
@@ -893,17 +871,7 @@ cfbd_stats_season_team <- function(year,
   }
 
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
-  }
-  if (!is.null(conference)) {
-    # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
+    team <- handle_accents(team)
   }
 
   if (!is.null(start_week) && !is.numeric(start_week) && nchar(start_week) > 2) {

--- a/R/cfbd_stats.R
+++ b/R/cfbd_stats.R
@@ -238,15 +238,16 @@ cfbd_stats_game_advanced <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/stats/game/advanced?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&week=", week,
-    "&team=", team,
-    "&opponent=", opponent,
-    "&excludeGarbageTime=", excl_garbage_time,
-    "&seasonType=", season_type
+  query_params <- list(
+    "year" = year,
+    "week" = week,
+    "team" = team,
+    "opponent" = opponent,
+    "excludeGarbageTime" = excl_garbage_time,
+    "seasonType" = season_type
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -452,14 +453,15 @@ cfbd_stats_season_advanced <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/stats/season/advanced?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&team=", team,
-    "&excludeGarbageTime=", excl_garbage_time,
-    "&startWeek=", start_week,
-    "&endWeek=", end_week
+  query_params <- list(
+    "year" = year,
+    "team" = team,
+    "excludeGarbageTime" = excl_garbage_time,
+    "startWeek" = start_week,
+    "endWeek" = end_week
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
@@ -921,15 +923,16 @@ cfbd_stats_season_team <- function(year,
 
   base_url <- "https://api.collegefootballdata.com/stats/season?"
 
-  full_url <- paste0(
-    base_url,
-    "year=", year,
-    "&seasonType=", season_type,
-    "&startWeek=", start_week,
-    "&endWeek=", end_week,
-    "&team=", team,
-    "&conference=", conference
+  query_params <- list(
+    "year" = year,
+    "seasonType" = season_type,
+    "startWeek" = start_week,
+    "endWeek" = end_week,
+    "team" = team,
+    "conference" = conference
   )
+
+  full_url <- httr::modify_url(base_url, query=query_params)
 
   # Check for CFBD API key
   if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)

--- a/R/cfbd_stats.R
+++ b/R/cfbd_stats.R
@@ -211,7 +211,7 @@ cfbd_stats_game_advanced <- function(year,
   opponent <- handle_accents(opponent)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/stats/game/advanced?"
+  base_url <- "https://api.collegefootballdata.com/stats/game/advanced"
   query_params <- list(
     "year" = year,
     "week" = week,
@@ -398,7 +398,7 @@ cfbd_stats_season_advanced <- function(year,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/stats/season/advanced?"
+  base_url <- "https://api.collegefootballdata.com/stats/season/advanced"
   query_params <- list(
     "year" = year,
     "team" = team,
@@ -585,7 +585,7 @@ cfbd_stats_season_player <- function(year,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/stats/player/season?"
+  base_url <- "https://api.collegefootballdata.com/stats/player/season"
   query_params = list(
     "year" = year,
     "team" = team,
@@ -789,7 +789,7 @@ cfbd_stats_season_team <- function(year,
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/stats/season?"
+  base_url <- "https://api.collegefootballdata.com/stats/season"
   query_params <- list(
     "year" = year,
     "seasonType" = season_type,

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -374,7 +374,7 @@ cfbd_team_matchup <- function(team1, team2, min_year = NULL, max_year = NULL) {
   }
 
   if (!is.null(team1)) {
-    team <- handle_accents(team)
+    team1 <- handle_accents(team1)
   }
   if (!is.null(team2)) {
     team2 <- handle_accents(team2)

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -137,6 +137,7 @@ cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recen
 
   }
 
+  df <- data.frame()
   tryCatch(
     expr = {
 
@@ -151,8 +152,8 @@ cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recen
       locs <- df$location
       locs <- locs %>%
         jsonlite::flatten() %>%
-        rename(venue_id = "id")
-      df <- df %>% select(-"location")
+        dplyr::rename(venue_id = "id")
+      df <- df %>% dplyr::select(-"location")
       # suppressWarnings(
       #   logos_list <- df %>%
       #     dplyr::group_by(.data$id) %>%

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -97,7 +97,6 @@ NULL
 #' @keywords Teams
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom dplyr rename
 #' @export
@@ -112,8 +111,6 @@ NULL
 cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recent_cfb_season()) {
   if (!is.null(conference)) {
     # # Check conference parameter in conference abbreviations, if not NULL
-    # Encode conference parameter for URL, if not NULL
-    conference <- utils::URLencode(conference, reserved = TRUE)
 
     base_url <- "https://api.collegefootballdata.com/teams?"
 
@@ -228,7 +225,6 @@ cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recen
 #' @keywords Team Matchup Records
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @importFrom dplyr rename mutate select
@@ -251,20 +247,10 @@ cfbd_team_matchup_records <- function(team1, team2, min_year = NULL, max_year = 
   }
 
   if (!is.null(team1)) {
-    if (team1 == "San Jose State") {
-      team1 <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team1 parameter for URL if not NULL
-      team1 <- utils::URLencode(team1, reserved = TRUE)
-    }
+    team1 <- handle_accents(team1)
   }
-  if (!is.null(team1)) {
-    if (team2 == "San Jose State") {
-      team2 <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team2 parameter for URL if not NULL
-      team2 <- utils::URLencode(team2, reserved = TRUE)
-    }
+  if (!is.null(team2)) {
+    team2 <- handle_accents(team2)
   }
 
   base_url <- "https://api.collegefootballdata.com/teams/matchup?"
@@ -363,7 +349,6 @@ cfbd_team_matchup_records <- function(team1, team2, min_year = NULL, max_year = 
 #' @keywords Team Matchup
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom janitor clean_names
 #' @importFrom glue glue
@@ -389,20 +374,10 @@ cfbd_team_matchup <- function(team1, team2, min_year = NULL, max_year = NULL) {
   }
 
   if (!is.null(team1)) {
-    if (team1 == "San Jose State") {
-      team1 <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team1 parameter for URL if not NULL
-      team1 <- utils::URLencode(team1, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
-  if (!is.null(team1)) {
-    if (team2 == "San Jose State") {
-      team2 <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team2 parameter for URL if not NULL
-      team2 <- utils::URLencode(team2, reserved = TRUE)
-    }
+  if (!is.null(team2)) {
+    team2 <- handle_accents(team2)
   }
 
   base_url <- "https://api.collegefootballdata.com/teams/matchup?"
@@ -491,7 +466,6 @@ cfbd_team_matchup <- function(team1, team2, min_year = NULL, max_year = NULL) {
 #' @importFrom dplyr rename mutate
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export
@@ -509,12 +483,7 @@ cfbd_team_roster <- function(year, team = NULL) {
 
 
   if (!is.null(team)) {
-    if (team == "San Jose State") {
-      team <- utils::URLencode(paste0("San Jos", "\u00e9", " State"), reserved = TRUE)
-    } else {
-      # Encode team1 parameter for URL if not NULL
-      team <- utils::URLencode(team, reserved = TRUE)
-    }
+    team <- handle_accents(team)
   }
   base_url <- "https://api.collegefootballdata.com/roster?"
 
@@ -582,7 +551,6 @@ cfbd_team_roster <- function(year, team = NULL) {
 #' @keywords Team talent
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET
-#' @importFrom utils URLencode
 #' @importFrom cli cli_abort
 #' @importFrom glue glue
 #' @export

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -62,9 +62,10 @@ NULL
 #' @param conference (*String* optional): Conference abbreviation - Select a valid FBS conference
 #' Conference abbreviations P5: ACC, B12, B1G, SEC, PAC,
 #' Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC
+#' Required if year not provided
 #' @param only_fbs (*Logical* default TRUE): Filter for only returning FBS teams for a given year.
 #' If year is left blank while only_fbs is TRUE, then will return values for most current year
-#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*). Filter for getting a list of major division team for a given year
+#' @param year (*Integer* optional): Year, 4 digit format (*YYYY*). Filter for getting a list of major division team for a given year. Required if conference not provided
 #' @return [cfbd_team_info()] - A data frame with 12 variables:
 #' \describe{
 #'   \item{`team_id`: integer.}{Referencing team id.}

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -510,6 +510,7 @@ cfbd_team_roster <- function(year, team = NULL) {
 cfbd_team_talent <- function(year = most_recent_cfb_season()) {
 
   # Validation ----
+  validate_api_key()
   validate_year(year)
 
   # Query API ----

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -256,6 +256,7 @@ cfbd_team_matchup_records <- function(team1, team2, min_year = NULL, max_year = 
       df <- res %>%
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON()
+      if (purrr::is_empty(df$games)) stop(call. = F)
       min_season <- min(df$games$season)
       max_season <- max(df$games$season)
       df[['games']] <- NULL
@@ -370,7 +371,7 @@ cfbd_team_matchup <- function(team1, team2, min_year = NULL, max_year = NULL) {
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON() %>%
         purrr::pluck("games")
-      if (nrow(df) == 0) {
+      if (is.null(df) || nrow(df) == 0) {
         warning("The data pulled from the API was empty.")
         return(NULL)
       }

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -243,7 +243,6 @@ cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recen
 #'
 cfbd_team_matchup_records <- function(team1, team2, min_year = NULL, max_year = NULL) {
 
-  #to-do: add handling for startYear and endYear populating with args
   if(!is.null(min_year)&& !is.numeric(min_year) && nchar(min_year) != 4){
     cli::cli_abort("Enter valid min_year as a number (YYYY)")
   }

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -120,7 +120,7 @@ cfbd_team_info <- function(conference = NULL, only_fbs = TRUE, year = most_recen
   if (!is.null(conference)) {
     # # Check conference parameter in conference abbreviations, if not NULL
 
-    base_url <- "https://api.collegefootballdata.com/teams?"
+    base_url <- "https://api.collegefootballdata.com/teams"
     query_params <- list(
       "conference" = conference,
       "year" = year
@@ -237,7 +237,7 @@ cfbd_team_matchup_records <- function(team1, team2, min_year = NULL, max_year = 
   team2 <- handle_accents(team2)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/teams/matchup?"
+  base_url <- "https://api.collegefootballdata.com/teams/matchup"
   query_params <- list(
     "team1" = team1,
     "team2" = team2,
@@ -351,7 +351,7 @@ cfbd_team_matchup <- function(team1, team2, min_year = NULL, max_year = NULL) {
   team2 <- handle_accents(team2)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/teams/matchup?"
+  base_url <- "https://api.collegefootballdata.com/teams/matchup"
   query_params <- list(
     "team1" = team1,
     "team2" = team2,
@@ -445,7 +445,7 @@ cfbd_team_roster <- function(year, team = NULL) {
   team <- handle_accents(team)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/roster?"
+  base_url <- "https://api.collegefootballdata.com/roster"
   query_params <- list(
     "year" = year,
     "team" = team
@@ -517,7 +517,7 @@ cfbd_team_talent <- function(year = most_recent_cfb_season()) {
   validate_year(year)
 
   # Query API ----
-  base_url <- "https://api.collegefootballdata.com/talent?"
+  base_url <- "https://api.collegefootballdata.com/talent"
   query_params <- list(
     "year" = year
   )

--- a/R/cfbd_venues.R
+++ b/R/cfbd_venues.R
@@ -33,18 +33,15 @@
 #' @export
 
 cfbd_venues <- function() {
+
+  # Validation ----
+  validate_api_key()
+
+  # Query API ----
   full_url <- "https://api.collegefootballdata.com/venues"
 
-  # Check for CFBD API key
-  if (!has_cfbd_key()) stop("CollegeFootballData.com now requires an API key.", "\n       See ?register_cfbd for details.", call. = FALSE)
-
   # Create the GET request and set response as res
-  res <- httr::RETRY(
-    "GET", full_url,
-    httr::add_headers(Authorization = paste("Bearer", cfbd_key()))
-  )
-
-  # Check the result
+  res <- get_req(full_url)
   check_status(res)
 
   # Get the content and return it as data.frame

--- a/R/espn_cfb_pbp.R
+++ b/R/espn_cfb_pbp.R
@@ -19,7 +19,7 @@ espn_cfb_pbp <- function(game_id, epa_wpa = FALSE){
   old <- options(list(stringsAsFactors = FALSE, scipen = 999))
   on.exit(options(old))
 
-  play_base_url <- "http://site.api.espn.com/apis/site/v2/sports/football/college-football/summary?"
+  play_base_url <- "http://site.api.espn.com/apis/site/v2/sports/football/college-football/summary"
 
   ## Inputs
   ## game_id

--- a/R/utils.R
+++ b/R/utils.R
@@ -295,7 +295,7 @@ validate_season_type <- function(season_type = NULL, allow_both = TRUE){
 validate_id <- function(id = NULL){
   if(!is.null(id)){
     checks <- c(
-      num_check <- !is.numeric(id)
+      num_check <- is.numeric(id)
     )
     if(!all(checks)){
       cli::cli_abort(glue::glue("Enter valid {deparse(substitute(id))} (numeric value)"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -215,3 +215,7 @@ rbindlist_with_attrs <- function(dflist){
   attr(out,"cfbfastR_type") <- cfbfastR_type
   out
 }
+
+handle_accents <- function(var){
+  ifelse(var == "San Jose State", "San José State", var)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -254,7 +254,7 @@ validate_week <- function(week = NULL){
   if(!is.null(week)){
     checks <- c(
       num_check = is.numeric(week),
-      range_check = between(as.numeric(week), 1, 15)
+      range_check = dplyr::between(as.numeric(week), 1, 15)
     )
     if(!all(checks)){
       cli::cli_abort(glue::glue("Enter valid {deparse(substitute(week))} 1-15\n(14 for seasons pre-playoff, i.e. 2014 or earlier)"))


### PR DESCRIPTION
## Addresses #106
While not all CFBD API endpoints changed in the transition to V2, certain changes have caused issues with the `cfbd_*` functions, causing [issues or unexpected results](https://github.com/sportsdataverse/cfbfastR/issues/106). This PR attempts to correct each of the `cfbd_*` functions and ensure expected results. Some of the returned fields have changed names slightly, so let me know if I missed any name clean up, but largely this PR does a few main things:

## Changes
### Across all `cfbd_*` models
  - Replace all instances of `paste0` created urls with `http::modify_url` for better url creation
    - This includes models that were not necessarily "broken" but I changed them to keep consistency

### Model specific changes
  - `cfbd_betting`
    - Changed NA type to `NA_int_` for overUnder and spread to align with API result
  - `cfbd_drives`
    - Deprecates elapsed drive time as it is no longer available from the API, returning NA instead
    - I don't know why the diff is the whole file, I only made this change and the `modify_url` change
  - `cfbd_games`
    - Replaces instances of `school` variable in `cfbd_game_player_stats` with `team`
  - `cfbd_metrics`
    - Deprecates countable plays as it is no longer available from the API, returning NA instead
  - `cfbd_pbp_data`
    - Fixes a join that broke due to API field name change
    - Adds a `janitor::clean_names()` call because API results aren't snake_case
  - `cfbd_play`
    - Adds a `janitor::clean_names()` call because API results aren't snake_case
    - Corrects endpoints for all functions (`plays` instead of `play`)
  - `cfbd_players`
    - Replaces 2019 default with `most_recent_cfb_season()`
  - `cfbd_ratings`
    - Adds year or team check for `cfbd_ratings_sp` and `cfbd_ratings_srs`
  - `cfbd_recruiting`
    - Adds year or team check for `cfbd_recruiting_player` and `cfbd_recruiting_position`
  - `cfbd_teams`
    - Renames location ID to `venue_id` to match `cfbd_venues`
    - Adds dynamic handling of start and end year in `cfbd_team_matchup_records`
    - Fixes recruit ID naming in `cfbd_team_roster`
    - Adds year check for `cfbd_team_talent`
    - I don't know why the diff is the whole file

### Extra Changes
- Added validation utility functions to reduce reused if statements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Standardized API URL construction across all functions using a unified approach with query parameter lists.
  * Replaced manual URL encoding and special-case handling with a centralized helper function for team names with accented characters.
  * Centralized and enhanced input validation via dedicated helper functions for API keys, years, weeks, season types, and other parameters.
  * Updated default year parameters in several functions to dynamically use the most recent season.
  * Improved naming conventions and data extraction, including consistent column names, flattening nested data, and preserving team-related column names.
  * Simplified HTTP request handling by introducing a common request function with retry and authorization.
  * Deprecated or renamed certain output columns for clarity and consistency.
  * Enhanced empty data handling and response parsing in team matchup functions.
  * Adjusted data joining keys and fixed roster field references for accuracy.

* **Bug Fixes**
  * Fixed handling of empty or missing data in team matchups and roster fields.
  * Corrected join keys and data frame column references for accurate data merging and display.

* **Documentation**
  * Updated parameter documentation to reflect dynamic defaults and deprecated columns.
  * Clarified validation requirements and improved error messaging.

* **Chores**
  * Added new utility functions for API requests, input validation, and accent handling.
  * Added a new contributor, Brad Hill, to the package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->