### PR TITLE
add a receiving yardage case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@
   - Fixed `athlete_id` parameter for [```cfbd_play_stats_player()```](https://cfbfastR.sportsdataverse.org/reference/cfbd_play_stats_player.html) function and added more thorough documentation.
   - Fixed returned `position` to correct value (instead of NA) from [```cfbd_stats_season_player()```](https://cfbfastR.sportsdataverse.org/reference/cfbd_stats_season_player.html)
   - Added more thorough `season_type` parameter documentation across many functions
+  - Changed behavior of [```cfbd_pbp_data()```](https://cfbfastR.sportsdataverse.org/reference/cfbd_pbp_data.html) to substitute 3 timeouts per half when the data is missing from the API.
   
 
 # **cfbfastR v1.9.5**

--- a/R/cfbd_drives.R
+++ b/R/cfbd_drives.R
@@ -19,7 +19,7 @@
 #' Conference abbreviations P5: ACC, B12, B1G, SEC, PAC
 #' Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC
 #' @param division (*String* optional): Division abbreviation - Select a valid division: fbs/fcs/ii/iii
-#' @return [cfbd_drives()] - A data frame with 23 variables as follows:
+#' @return [cfbd_drives()] - A data frame with variables as follows:
 #' \describe{
 #'   \item{`offense`:character.}{Drive offense.}
 #'   \item{`offense_conference`:character.}{Drive offense's conference.}

--- a/R/cfbd_drives.R
+++ b/R/cfbd_drives.R
@@ -47,8 +47,8 @@
 #'   \item{`time_seconds_start`:integer.}{Seconds at drive start.}
 #'   \item{`time_minutes_end`:integer.}{Minutes at drive end.}
 #'   \item{`time_seconds_end`:integer.}{Seconds at drive end.}
-#'   \item{`time_minutes_elapsed`:double.}{DEPRECATED Minutes elapsed during drive.}
-#'   \item{`time_seconds_elapsed`:integer.}{DEPRECATED Seconds elapsed during drive.}
+#'   \item{`time_minutes_elapsed`:double.}{Minutes elapsed during drive.}
+#'   \item{`time_seconds_elapsed`:integer.}{Seconds elapsed during drive.}
 #' }
 #' @keywords Drives
 #' @importFrom jsonlite fromJSON
@@ -61,7 +61,7 @@
 #' @export
 #' @examples
 #' \donttest{
-#'   try(cfbd_drives(2018, week = 1, team = "TCU"))
+#'   try(cfbd_drives(year=2018, week = 1, team = "TCU"))
 #'
 #'   try(cfbd_drives(2018, team = "Texas A&M", defense_conference = "SEC"))
 #' }
@@ -120,10 +120,10 @@ cfbd_drives <- function(year,
           "time_minutes_start" = "startTime.minutes",
           "time_seconds_start" = "startTime.seconds",
           "time_minutes_end" = "endTime.minutes",
-          "time_seconds_end" = "endTime.seconds"
+          "time_seconds_end" = "endTime.seconds",
+          "time_minutes_elapsed" = "elapsed.minutes",
+          "time_seconds_elapsed" = "elapsed.seconds"
         ) %>%
-        dplyr::mutate(time_minutes_elapsed = NA,
-                      time_seconds_elapsed = NA) %>%
         janitor::clean_names()
 
       # 2021 games with pbp data from another (non-ESPN) source include extra unclear columns for hours.

--- a/R/cfbd_pbp_data.R
+++ b/R/cfbd_pbp_data.R
@@ -1017,7 +1017,8 @@ add_play_counts <- function(play_df) {
     dplyr::group_by(.data$game_id) %>%
     dplyr::summarise(
       off_timeouts_na = all(is.na(.data$offense_timeouts)),
-      def_timeouts_na = all(is.na(.data$defense_timeouts))
+      def_timeouts_na = all(is.na(.data$defense_timeouts)),
+      .groups = "drop"
     )
   if (play_df_timeout_check$off_timeouts_na | play_df_timeout_check$def_timeouts_na) {
     play_df <- play_df %>%

--- a/R/cfbd_pbp_data.R
+++ b/R/cfbd_pbp_data.R
@@ -390,8 +390,8 @@
 #' @family CFBD PBP
 #' @details
 #' ```r
-#'  # Get play by play data for 2018 regular season week 1
-#'  cfbd_pbp_data(year = 2024, week = 1, season_type = 'regular', epa_wpa = TRUE)
+#'  # Get play by play data for 2025 regular season week 1
+#'  cfbd_pbp_data(year = 2025, week = 1, season_type = 'regular', epa_wpa = TRUE)
 #' ```
 #' @export
 
@@ -457,7 +457,7 @@ cfbd_pbp_data <- function(year,
   raw_play_df <- do.call(data.frame, raw_play_df)
 
   if (nrow(raw_play_df) == 0) {
-      warning("Most likely a bye week, the data pulled from the API was empty. Returning nothing
+    warning("Most likely a bye week, the data pulled from the API was empty. Returning nothing
               for this one week or team.")
     return(NULL)
   }
@@ -525,11 +525,11 @@ cfbd_pbp_data <- function(year,
     ) %>%
     dplyr::mutate(drive_id = as.numeric(.data$drive_id)) %>%
     dplyr::left_join(clean_drive_df,
-      by = c(
-        "drive_id" = "drive_drive_id",
-        "game_id" = "drive_game_id"
-      ),
-      suffix = c("_play", "_drive")
+                     by = c(
+                       "drive_id" = "drive_drive_id",
+                       "game_id" = "drive_game_id"
+                     ),
+                     suffix = c("_play", "_drive")
     )
 
   rm_cols <- c(
@@ -565,9 +565,9 @@ cfbd_pbp_data <- function(year,
 
   if (epa_wpa) {
     if (year <= 2005) {
-        warning(
-          "Data Quality prior to 2005 is not as consistent. This can affect the EPA/WPA values, proceed with caution."
-        )
+      warning(
+        "Data Quality prior to 2005 is not as consistent. This can affect the EPA/WPA values, proceed with caution."
+      )
     }
 
     #---- Purrr Map Function -----
@@ -1013,18 +1013,30 @@ add_play_counts <- function(play_df) {
     "Pass Interception Return",
     "Pass Interception Return Touchdown"
   )
-
+  play_df_timeout_check <- play_df %>%
+    dplyr::group_by(.data$game_id) %>%
+    dplyr::summarise(
+      off_timeouts_na = all(is.na(.data$offense_timeouts)),
+      def_timeouts_na = all(is.na(.data$defense_timeouts))
+    )
+  if (play_df_timeout_check$off_timeouts_na | play_df_timeout_check$def_timeouts_na) {
+    play_df <- play_df %>%
+      dplyr::mutate(
+        offense_timeouts = 3,
+        defense_timeouts = 3
+      )
+  }
   play_df <-
     play_df %>%
     dplyr::group_by(.data$game_id) %>%
     dplyr::arrange(.data$id_play, .by_group = TRUE) %>%
     dplyr::mutate(
       play_type = ifelse(.data$play_type != "End of Half" & .data$play_text %in% c("End of 2nd Quarter"),
-        "End of Half", .data$play_type
+                         "End of Half", .data$play_type
       ),
       play_type = ifelse(.data$play_type != "End Period" &
-        .data$play_text %in% c("End of 3rd Quarter", "End of 1st Quarter"),
-      "End Period", .data$play_type
+                           .data$play_text %in% c("End of 3rd Quarter", "End of 1st Quarter"),
+                         "End Period", .data$play_type
       ),
       play = ifelse(!(.data$play_type %in% c(
         "End Period", "End of Half", "End of Game",
@@ -1036,7 +1048,7 @@ add_play_counts <- function(play_df) {
       game_event_number = cumsum(.data$event),
       game_row_number = 1:dplyr::n(),
       half_clock_minutes = ifelse(.data$period %in% c(1, 3), 15 +
-        .data$clock_minutes, .data$clock_minutes),
+                                    .data$clock_minutes, .data$clock_minutes),
       TimeSecsRem = .data$half_clock_minutes * 60 + .data$clock_seconds,
       Under_two = .data$TimeSecsRem <= 120,
       Under_three = .data$TimeSecsRem <= 180,
@@ -1044,9 +1056,9 @@ add_play_counts <- function(play_df) {
       kickoff_play = ifelse(.data$play_type %in% kickoff_vec, 1, 0),
       #---- Define pos_team/def_pos_team variables -----
       pos_team = ifelse(.data$offense_play == .data$home & .data$kickoff_play == 1, .data$away,
-        ifelse(.data$offense_play == .data$away & .data$kickoff_play == 1,
-          .data$home, .data$offense_play
-        )
+                        ifelse(.data$offense_play == .data$away & .data$kickoff_play == 1,
+                               .data$home, .data$offense_play
+                        )
       ),
       def_pos_team = ifelse(.data$pos_team == .data$home, .data$away, .data$home),
       pos_team_score = ifelse(.data$kickoff_play == 1, .data$defense_score, .data$offense_score),
@@ -1056,9 +1068,9 @@ add_play_counts <- function(play_df) {
       lead_pos_team = dplyr::lead(.data$pos_team, 1),
       lead_pos_team2 = dplyr::lead(.data$pos_team, 2),
       receives_2H_kickoff = ifelse(.data$game_play_number == 1 &
-        .data$def_pos_team == .data$home, 1,
-      ifelse(.data$game_play_number == 1 &
-        .data$def_pos_team == .data$away, 0, NA_real_)
+                                     .data$def_pos_team == .data$home, 1,
+                                   ifelse(.data$game_play_number == 1 &
+                                            .data$def_pos_team == .data$away, 0, NA_real_)
       ),
       score_diff = .data$offense_score - .data$defense_score,
       lag_score_diff = dplyr::lag(.data$score_diff, 1),
@@ -1068,24 +1080,24 @@ add_play_counts <- function(play_df) {
       lead_offense_play = dplyr::lead(.data$offense_play, 1),
       lead_offense_play2 = dplyr::lead(.data$offense_play, 2),
       score_pts = ifelse(.data$lag_offense_play == .data$offense_play,
-        (.data$score_diff - .data$lag_score_diff),
-        (.data$score_diff + .data$lag_score_diff)
+                         (.data$score_diff - .data$lag_score_diff),
+                         (.data$score_diff + .data$lag_score_diff)
       ),
       score_diff_start = ifelse(.data$lag_offense_play == .data$offense_play &
-        !(.data$play_type %in% kickoff_vec),
-      .data$lag_score_diff,
-      -1 * .data$lag_score_diff
+                                  !(.data$play_type %in% kickoff_vec),
+                                .data$lag_score_diff,
+                                -1 * .data$lag_score_diff
       ),
       pos_score_diff = .data$pos_team_score - .data$def_pos_team_score,
       lag_pos_score_diff = dplyr::lag(.data$pos_score_diff, 1),
       lag_pos_score_diff = ifelse(.data$game_play_number == 1, 0, .data$lag_pos_score_diff),
       pos_score_pts = ifelse(.data$lag_pos_team == .data$pos_team,
-        (.data$pos_score_diff - .data$lag_pos_score_diff),
-        (.data$pos_score_diff + .data$lag_pos_score_diff)
+                             (.data$pos_score_diff - .data$lag_pos_score_diff),
+                             (.data$pos_score_diff + .data$lag_pos_score_diff)
       ),
       pos_score_diff_start = ifelse(.data$lag_pos_team == .data$pos_team,
-        .data$lag_pos_score_diff,
-        -1 * .data$lag_pos_score_diff
+                                    .data$lag_pos_score_diff,
+                                    -1 * .data$lag_pos_score_diff
       )
       # TO-DO: define a fix for end of period plays on possession changing plays
     ) %>%
@@ -1104,8 +1116,8 @@ add_play_counts <- function(play_df) {
     ) %>%
     dplyr::group_by(.data$game_id, .data$half) %>%
     dplyr::arrange(.data$game_id, .data$half, .data$period,
-      -.data$TimeSecsRem, .data$id_play,
-      .by_group = TRUE
+                   -.data$TimeSecsRem, .data$id_play,
+                   .by_group = TRUE
     ) %>%
     dplyr::mutate(
       #---- Half Row/Event/Play Numbers -----
@@ -1172,18 +1184,18 @@ add_play_counts <- function(play_df) {
       lead_play_text3 = dplyr::lead(.data$play_text, 3),
       #-- Change of possession by lead('offense_play', 1)----
       change_of_poss = ifelse(.data$offense_play == .data$lead_offense_play &
-        (!(.data$play_type %in% c("End Period", "End of Half")) | is.na(.data$lead_play_type)), 0,
-      ifelse(.data$offense_play == .data$lead_offense_play2 &
-        ((.data$play_type %in% c("End Period", "End of Half")) | is.na(.data$lead_play_type)), 0, 1)
+                                (!(.data$play_type %in% c("End Period", "End of Half")) | is.na(.data$lead_play_type)), 0,
+                              ifelse(.data$offense_play == .data$lead_offense_play2 &
+                                       ((.data$play_type %in% c("End Period", "End of Half")) | is.na(.data$lead_play_type)), 0, 1)
       ),
       change_of_poss = ifelse(is.na(.data$change_of_poss), 0, .data$change_of_poss),
       #-- Change of pos_team by lead('pos_team', 1)----
       change_of_pos_team = ifelse(.data$pos_team == .data$lead_pos_team &
-        (!(.data$lead_play_type %in% c("End Period", "End of Half")) |
-          is.na(.data$lead_play_type)), 0,
-      ifelse(.data$pos_team == .data$lead_pos_team2 &
-        ((.data$lead_play_type %in% c("End Period", "End of Half")) |
-          is.na(.data$lead_play_type)), 0, 1)
+                                    (!(.data$lead_play_type %in% c("End Period", "End of Half")) |
+                                       is.na(.data$lead_play_type)), 0,
+                                  ifelse(.data$pos_team == .data$lead_pos_team2 &
+                                           ((.data$lead_play_type %in% c("End Period", "End of Half")) |
+                                              is.na(.data$lead_play_type)), 0, 1)
       ),
       change_of_pos_team = ifelse(is.na(.data$change_of_pos_team), 0, .data$change_of_pos_team),
       pos_team_timeouts = ifelse(.data$kickoff_play == 1, .data$defense_timeouts, .data$offense_timeouts),
@@ -1250,8 +1262,8 @@ clean_drive_dat <- function(play_df) {
   play_df <- play_df %>%
     dplyr::group_by(.data$game_id, .data$half) %>%
     dplyr::arrange(.data$game_id, .data$half, .data$period,
-      -.data$TimeSecsRem, -.data$lead_TimeSecsRem, .data$id_play,
-      .by_group = TRUE
+                   -.data$TimeSecsRem, -.data$lead_TimeSecsRem, .data$id_play,
+                   .by_group = TRUE
     ) %>%
     dplyr::mutate(
       #---- Define Lag Pos Team/Kickoff Play/Punt/Scoring/Turnover/Downs Turnover----
@@ -1492,16 +1504,16 @@ clean_drive_dat <- function(play_df) {
     dplyr::ungroup() %>%
     dplyr::group_by(.data$game_id) %>%
     dplyr::arrange(.data$game_id, .data$half, .data$period,
-      -.data$TimeSecsRem, -.data$lead_TimeSecsRem,
-      .data$id_play,
-      .by_group = TRUE
+                   -.data$TimeSecsRem, -.data$lead_TimeSecsRem,
+                   .data$id_play,
+                   .by_group = TRUE
     ) %>%
     dplyr::mutate(drive_num = cumsum(.data$drive_numbers)) %>%
     dplyr::group_by(.data$game_id, .data$half, .data$drive_num) %>%
     dplyr::arrange(.data$game_id, .data$half, .data$period,
-      -.data$TimeSecsRem, -.data$lead_TimeSecsRem,
-      .data$id_play,
-      .by_group = TRUE
+                   -.data$TimeSecsRem, -.data$lead_TimeSecsRem,
+                   .data$id_play,
+                   .by_group = TRUE
     ) %>%
     tidyr::fill("drive_result_detailed", .direction = c("updown")) %>%
     tidyr::fill("drive_result2", .direction = c("updown")) %>%
@@ -1517,12 +1529,12 @@ clean_drive_dat <- function(play_df) {
       lag_drive_result_detailed = dplyr::lag(.data$drive_result_detailed, 1),
       lead_drive_result_detailed = dplyr::lead(.data$drive_result_detailed, 1),
       drive_result_detailed = ifelse(is.na(.data$drive_result_detailed) &
-        .data$play_type %in% c("Defensive 2pt Conversion", "Uncategorized", "Two Point Rush"),
-      .data$lag_drive_result_detailed,
-      .data$drive_result_detailed
+                                       .data$play_type %in% c("Defensive 2pt Conversion", "Uncategorized", "Two Point Rush"),
+                                     .data$lag_drive_result_detailed,
+                                     .data$drive_result_detailed
       ),
       drive_result_detailed = ifelse(is.na(.data$drive_result_detailed) & .data$kickoff_play == 1,
-        .data$lead_drive_result_detailed, .data$drive_result_detailed
+                                     .data$lead_drive_result_detailed, .data$drive_result_detailed
       ),
       drive_scoring = ifelse(is.na(.data$drive_scoring), 0, .data$drive_scoring),
       new_drive_pts = ifelse(is.na(.data$new_drive_pts), 0, .data$new_drive_pts),
@@ -1532,8 +1544,8 @@ clean_drive_dat <- function(play_df) {
     ) %>%
     dplyr::group_by(.data$game_id, .data$id_drive) %>%
     dplyr::arrange(.data$game_id, .data$half, .data$period,
-      -.data$TimeSecsRem, -.data$lead_TimeSecsRem, .data$id_play,
-      .by_group = TRUE
+                   -.data$TimeSecsRem, -.data$lead_TimeSecsRem, .data$id_play,
+                   .by_group = TRUE
     ) %>%
     dplyr::mutate(
       drive_play = ifelse(!(.data$play_type %in% c(
@@ -1557,8 +1569,8 @@ clean_drive_dat <- function(play_df) {
         yards_to_goal = as.numeric(.data$yards_to_goal),
         yards_gained = as.numeric(.data$yards_gained),
         Goal_To_Go = ifelse(stringr::str_detect(.data$play_type, "Field Goal"),
-          .data$distance >= (.data$yards_to_goal),
-          .data$distance >= .data$yards_to_goal
+                            .data$distance >= (.data$yards_to_goal),
+                            .data$distance >= .data$yards_to_goal
         )
       )
   )
@@ -1748,8 +1760,8 @@ prep_epa_df_after <- function(dat) {
           (.data$play_type %in% defense_score_vec) |
             (.data$play_type %in% turnover_vec) |
             ((.data$play_type %in% normalplay | .data$play_type == "Fumble Recovery (Own)") &
-              .data$yards_gained < .data$distance &
-              .data$down == 4), 1, 0
+               .data$yards_gained < .data$distance &
+               .data$down == 4), 1, 0
         ),
       down = as.numeric(.data$down),
       lead_down = as.numeric(.data$lead_down),
@@ -1824,17 +1836,17 @@ prep_epa_df_after <- function(dat) {
         #--penalty first down conversions, 10 or to goal
         .data$play_type %in% penalty &
           .data$penalty_1st_conv ~ as.numeric(ifelse(.data$yards_to_goal - .data$yards_gained <= 10 &
-          .data$yards_to_goal - .data$yards_gained >= 0,
-        as.numeric(.data$yards_to_goal), 10
-        )),
+                                                       .data$yards_to_goal - .data$yards_gained >= 0,
+                                                     as.numeric(.data$yards_to_goal), 10
+          )),
         #--penalty without first down conversion
         .data$play_type %in% penalty & !.data$penalty_declined &
           !.data$penalty_1st_conv &
           !.data$penalty_offset ~ as.numeric(ifelse((.data$yards_gained >= .data$distance) &
-          (.data$yards_to_goal - .data$yards_gained <= 10) &
-          .data$yards_to_goal - .data$yards_gained >= 0,
-        as.numeric(.data$yards_to_goal), 10
-        )),
+                                                      (.data$yards_to_goal - .data$yards_gained <= 10) &
+                                                      .data$yards_to_goal - .data$yards_gained >= 0,
+                                                    as.numeric(.data$yards_to_goal), 10
+          )),
         ## --normal plays
         (.data$play_type %in% normalplay | .data$play_type == "Fumble Recovery (Own)") &
           .data$yards_gained >= .data$distance &
@@ -1887,26 +1899,26 @@ prep_epa_df_after <- function(dat) {
       # TODO - Add these variables to the documentation and select outputs
       row = 1:dplyr::n(),
       first_by_penalty = ifelse(.data$play_type %in% penalty & .data$penalty_1st_conv, 1,
-        ifelse(.data$play_type %in% penalty & .data$penalty_declined &
-          .data$penalty_offset & !.data$penalty_1st_conv &
-          .data$yards_gained > .data$distance, 1,
-        ifelse(.data$play_type %in% penalty & .data$penalty_declined &
-          !.data$penalty_offset & !.data$penalty_1st_conv &
-          .data$yards_gained >= .data$distance, 1, 0)
-        )
+                                ifelse(.data$play_type %in% penalty & .data$penalty_declined &
+                                         .data$penalty_offset & !.data$penalty_1st_conv &
+                                         .data$yards_gained > .data$distance, 1,
+                                       ifelse(.data$play_type %in% penalty & .data$penalty_declined &
+                                                !.data$penalty_offset & !.data$penalty_1st_conv &
+                                                .data$yards_gained >= .data$distance, 1, 0)
+                                )
       ),
       first_by_yards = ifelse((.data$play_type %in% normalplay | .data$play_type == "Fumble Recovery (Own)") &
-        .data$yards_gained >= .data$distance, 1, 0),
+                                .data$yards_gained >= .data$distance, 1, 0),
       lag_first_by_penalty3 = dplyr::lag(.data$first_by_penalty, 3),
       lag_first_by_penalty2 = dplyr::lag(.data$first_by_penalty, 2),
       lag_first_by_penalty = dplyr::lag(.data$first_by_penalty, 1),
       lag_first_by_penalty = ifelse(is.na(.data$lag_first_by_penalty) & !(.data$lag_play_type %in% penalty) |
-        .data$row == 1, 0, .data$lag_first_by_penalty),
+                                      .data$row == 1, 0, .data$lag_first_by_penalty),
       lag_first_by_yards3 = dplyr::lag(.data$first_by_yards, 3),
       lag_first_by_yards2 = dplyr::lag(.data$first_by_yards, 2),
       lag_first_by_yards = dplyr::lag(.data$first_by_yards, 1),
       lag_first_by_yards = ifelse(is.na(.data$lag_first_by_yards) & !(.data$lag_play_type %in% normalplay) &
-        (.data$lag_play_type != "Fumble Recovery (Own)") | .data$row == 1, 0, .data$lag_first_by_yards),
+                                    (.data$lag_play_type != "Fumble Recovery (Own)") | .data$row == 1, 0, .data$lag_first_by_yards),
       new_series = dplyr::if_else(
         .data$id_drive != dplyr::lag(.data$id_drive, 1) |
           .data$lag_first_by_yards == 1 | .data$lag_first_by_penalty == 1 |
@@ -1919,9 +1931,9 @@ prep_epa_df_after <- function(dat) {
     dat <- dat %>%
       dplyr::mutate(
         new_log_ydstogo = dplyr::if_else(.data$new_distance == 0 |
-          is.nan(log(.data$new_distance)) |
-          is.na(.data$new_distance),
-        log(1), log(.data$new_distance)
+                                           is.nan(log(.data$new_distance)) |
+                                           is.na(.data$new_distance),
+                                         log(1), log(.data$new_distance)
         )
       )
   )
@@ -1964,14 +1976,14 @@ prep_epa_df_after <- function(dat) {
         TRUE ~ 0
       ),
       firstD_by_penalty = ifelse((.data$lag_first_by_penalty == 1 & .data$lag_change_of_pos_team != 1 &
-        !(.data$lag_play_type %in% c("Timeout", "End Period"))) |
-        (.data$lag_first_by_penalty2 == 1 & .data$lag_change_of_pos_team2 != 1 &
-          (.data$lag_play_type %in% c("Timeout", "End Period"))) |
-        (.data$lag_first_by_penalty3 == 1 & .data$lag_change_of_pos_team3 != 1 &
-          (.data$lag_play_type %in% c("Timeout", "End Period") & (.data$lag_play_type2 %in% c("Timeout", "End Period")))), 1, 0),
+                                    !(.data$lag_play_type %in% c("Timeout", "End Period"))) |
+                                   (.data$lag_first_by_penalty2 == 1 & .data$lag_change_of_pos_team2 != 1 &
+                                      (.data$lag_play_type %in% c("Timeout", "End Period"))) |
+                                   (.data$lag_first_by_penalty3 == 1 & .data$lag_change_of_pos_team3 != 1 &
+                                      (.data$lag_play_type %in% c("Timeout", "End Period") & (.data$lag_play_type2 %in% c("Timeout", "End Period")))), 1, 0),
       firstD_by_penalty = dplyr::case_when(
         (.data$lag_first_by_penalty == 1 & .data$lag_change_of_pos_team != 1 &
-          !(.data$lag_play_type %in% c("Timeout", "End Period"))) ~ 1,
+           !(.data$lag_play_type %in% c("Timeout", "End Period"))) ~ 1,
         .data$lag_first_by_penalty2 == 1 & .data$lag_change_of_pos_team2 != 1 &
           (.data$lag_play_type %in% c("Timeout", "End Period")) ~ 1,
         .data$lag_first_by_penalty3 == 1 & .data$lag_change_of_pos_team3 != 1 &
@@ -1979,11 +1991,11 @@ prep_epa_df_after <- function(dat) {
         TRUE ~ 0
       ),
       firstD_by_yards = ifelse((.data$lag_first_by_yards == 1 & .data$lag_change_of_pos_team != 1 &
-        !(.data$lag_play_type %in% c("Timeout", "End Period"))) |
-        (.data$lag_first_by_yards2 == 1 & .data$lag_change_of_pos_team2 != 1 &
-          (.data$lag_play_type %in% c("Timeout", "End Period"))) |
-        (.data$lag_first_by_yards3 == 1 & .data$lag_change_of_pos_team3 != 1 &
-          (.data$lag_play_type %in% c("Timeout", "End Period") & (.data$lag_play_type2 %in% c("Timeout", "End Period")))), 1, 0),
+                                  !(.data$lag_play_type %in% c("Timeout", "End Period"))) |
+                                 (.data$lag_first_by_yards2 == 1 & .data$lag_change_of_pos_team2 != 1 &
+                                    (.data$lag_play_type %in% c("Timeout", "End Period"))) |
+                                 (.data$lag_first_by_yards3 == 1 & .data$lag_change_of_pos_team3 != 1 &
+                                    (.data$lag_play_type %in% c("Timeout", "End Period") & (.data$lag_play_type2 %in% c("Timeout", "End Period")))), 1, 0),
       new_id = .data$id_play
     ) %>%
     dplyr::ungroup() %>%
@@ -2005,7 +2017,7 @@ prep_epa_df_after <- function(dat) {
 
   #--End of Half Plays--------------------------
   end_of_half_plays <- (dat$new_TimeSecsRem == 0 |
-    (dat$end_of_half == 1 & !(dat$play_type %in% c("End Period", "End of Half", "End of Game"))))
+                          (dat$end_of_half == 1 & !(dat$play_type %in% c("End Period", "End of Half", "End of Game"))))
 
   if (any(end_of_half_plays)) {
     dat$new_yardline[end_of_half_plays] <- 100
@@ -2021,9 +2033,9 @@ prep_epa_df_after <- function(dat) {
   dat <- dat %>%
     dplyr::mutate(
       new_yardline = dplyr::if_else(is.na(.data$new_yardline) &
-        .data$play_type %in% c("Field Goal Missed", "Blocked Field Goal"),
-      100 - (.data$yards_to_goal - 9),
-      .data$new_yardline
+                                      .data$play_type %in% c("Field Goal Missed", "Blocked Field Goal"),
+                                    100 - (.data$yards_to_goal - 9),
+                                    .data$new_yardline
       )
     )
 

--- a/R/cfbd_play.R
+++ b/R/cfbd_play.R
@@ -147,7 +147,7 @@ cfbd_plays <- function(year = 2020,
     "playType" = play_type,
     "classification" = division
   )
-  full_url <- httr::modify_url(base_url, query=query_params)
+  full_url <- httr::modify_url(base_url, query = query_params)
 
   df <- data.frame()
   tryCatch(
@@ -304,7 +304,7 @@ cfbd_play_stats_player <- function(year = NULL,
     "statTypeId" = stat_type_id,
     "seasonType" = season_type
   )
-  full_url <- httr::modify_url(base_url, query=query_params)
+  full_url <- httr::modify_url(base_url, query = query_params)
 
   clean_df <- data.frame()
   tryCatch(
@@ -378,7 +378,7 @@ cfbd_play_stats_player <- function(year = NULL,
       colnames(df) <- gsub(" ", "_", tolower(colnames(df)))
 
       clean_df <- df %>%
-        dplyr::distinct_all() %>%
+        dplyr::distinct() %>%
         tidyr::unnest_wider("clock", names_sep = "_") %>%
         tidyr::pivot_wider(
           names_from = "stat_type",
@@ -389,7 +389,7 @@ cfbd_play_stats_player <- function(year = NULL,
 
       clean_df[cols[!(cols %in% colnames(clean_df))]] <- NA
 
-      clean_df[clean_df=="NULL"] <- NA
+      clean_df[clean_df == "NULL"] <- NA
 
       clean_df <- clean_df %>%
         dplyr::rename(dplyr::any_of(c(
@@ -861,7 +861,7 @@ cfbd_live_plays <- function(game_id) {
   query_params <- list(
     "gameId" = game_id
   )
-  full_url <- httr::modify_url(base_url, query=query_params)
+  full_url <- httr::modify_url(base_url, query = query_params)
 
   df <- data.frame()
   tryCatch(
@@ -918,10 +918,10 @@ cfbd_live_plays <- function(game_id) {
           "ppa_per_rush" = "epa_per_rush"
         )))
 
-      home_team_df <- df_teams %>% dplyr::filter(.data$home_away =="home")
+      home_team_df <- df_teams %>% dplyr::filter(.data$home_away == "home")
       home_team_df <- home_team_df %>% dplyr::select(-dplyr::any_of("home_away"))
       colnames(home_team_df) <- paste0("home_", colnames(home_team_df))
-      away_team_df <- df_teams %>% dplyr::filter(.data$home_away =="away")
+      away_team_df <- df_teams %>% dplyr::filter(.data$home_away == "away")
       away_team_df <- away_team_df %>% dplyr::select(-dplyr::any_of("home_away"))
       colnames(away_team_df) <- paste0("away_", colnames(away_team_df))
 

--- a/R/cfbd_play.R
+++ b/R/cfbd_play.R
@@ -270,8 +270,8 @@ cfbd_plays <- function(year = 2020,
 #' @export
 #' @examples
 #' \donttest{
-#'   try(cfbd_play_stats_player(game_id = 401110722))
-#'   try(cfbd_play_stats_player(year = 2023, week = 1))
+#'   try(cfbd_play_stats_player(game_id = 401628414))
+#'   try(cfbd_play_stats_player(year = 2025, week = 1))
 #' }
 cfbd_play_stats_player <- function(year = NULL,
                                    week = NULL,
@@ -321,8 +321,9 @@ cfbd_play_stats_player <- function(year = NULL,
         as.data.frame()
 
       cols <- c(
-        "game_id", "season", "week", "opponent", "team_score", "opponent_score",
-        "drive_id", "play_id", "period", "yards_to_goal", "down", "distance",
+        "game_id", "season", "week", "team",
+        "conference", "opponent", "team_score", "opponent_score",
+        "drive_id", "play_id", "period", "clock_minutes","clock_seconds", "yards_to_goal", "down", "distance",
         "athlete_id", "stat",
         "reception", "completion", "rush", "interception", "interception_thrown",
         "touchdown", "incompletion", "target", "fumble_recovered", "fumble_forced",
@@ -349,7 +350,7 @@ cfbd_play_stats_player <- function(year = NULL,
 
       )
 
-      df_cols <- data.frame(matrix(NA, nrow = 0, ncol = 86))
+      df_cols <- data.frame(matrix(NA, nrow = 0, ncol = 90))
 
       names(df_cols) <- cols
 
@@ -377,6 +378,7 @@ cfbd_play_stats_player <- function(year = NULL,
       colnames(df) <- gsub(" ", "_", tolower(colnames(df)))
 
       clean_df <- df %>%
+        dplyr::distinct_all() %>%
         tidyr::unnest_wider("clock", names_sep = "_") %>%
         tidyr::pivot_wider(
           names_from = "stat_type",
@@ -386,6 +388,8 @@ cfbd_play_stats_player <- function(year = NULL,
       colnames(clean_df) <- gsub(" ", "_", tolower(colnames(clean_df)))
 
       clean_df[cols[!(cols %in% colnames(clean_df))]] <- NA
+
+      clean_df[clean_df=="NULL"] <- NA
 
       clean_df <- clean_df %>%
         dplyr::rename(dplyr::any_of(c(
@@ -519,10 +523,96 @@ cfbd_play_stats_player <- function(year = NULL,
           "field_goal_blocked_player_id",
           "field_goal_blocked_player",
           "field_goal_blocked_stat"
-        ))) %>%
+        )))
+
+      clean_sack_df <- clean_df %>%
+        dplyr::group_by(.data$play_id) %>%
+        dplyr::summarize(
+          sack_player = paste(unique(na.omit(.data$sack_player)), collapse = ", "),
+          sack_player_id = paste(unique(na.omit(.data$sack_player_id)), collapse = ", "),
+          .groups = "drop"
+        )
+
+
+      clean_df <- clean_df %>%
+        dplyr::select(-"sack_player", -"sack_player_id") %>%
+        dplyr::left_join(clean_sack_df, by = "play_id") %>%
         dplyr::group_by(.data$play_id) %>%
         dplyr::summarise_all(coalesce_by_column) %>%
-        dplyr::ungroup()
+        dplyr::ungroup() %>%
+        dplyr::select(dplyr::any_of(c(
+          "game_id",
+          "season",
+          "week",
+          "team",
+          "conference",
+          "opponent",
+          "team_score",
+          "opponent_score",
+          "drive_id",
+          "play_id",
+          "period",
+          "clock_minutes",
+          "clock_seconds",
+          "yards_to_goal",
+          "down",
+          "distance",
+          "reception_player_id",
+          "reception_player",
+          "reception_yds",
+          "completion_player_id",
+          "completion_player",
+          "completion_yds",
+          "rush_player_id",
+          "rush_player",
+          "rush_yds",
+          "interception_player_id",
+          "interception_player",
+          "interception_stat",
+          "interception_thrown_player_id",
+          "interception_thrown_player",
+          "interception_thrown_stat",
+          "touchdown_player_id",
+          "touchdown_player",
+          "touchdown_stat",
+          "incompletion_player_id",
+          "incompletion_player",
+          "incompletion_stat",
+          "target_player_id",
+          "target_player",
+          "target_stat",
+          "fumble_recovered_player_id",
+          "fumble_recovered_player",
+          "fumble_recovered_stat",
+          "fumble_forced_player_id",
+          "fumble_forced_player",
+          "fumble_forced_stat",
+          "fumble_player_id",
+          "fumble_player",
+          "fumble_stat",
+          "sack_player_id",
+          "sack_player",
+          "sack_stat",
+          "sack_taken_player_id",
+          "sack_taken_player",
+          "sack_taken_stat",
+          "pass_breakup_player_id",
+          "pass_breakup_player",
+          "pass_breakup_stat",
+          "field_goal_attempt_player_id",
+          "field_goal_attempt_player",
+          "field_goal_attempt_stat",
+          "field_goal_made_player_id",
+          "field_goal_made_player",
+          "field_goal_made_stat",
+          "field_goal_missed_player_id",
+          "field_goal_missed_player",
+          "field_goal_missed_stat",
+          "field_goal_blocked_player_id",
+          "field_goal_blocked_player",
+          "field_goal_blocked_stat"
+        )))
+
 
 
       clean_df <- clean_df %>%
@@ -650,102 +740,106 @@ cfbd_play_types <- function() {
 #' Can be found using the [cfbd_game_info()] function
 #' @return [cfbd_live_plays()] - A data frame with 94 columns:
 #'
-#'   |col_name                         |types     |
-#'   |:--------------------------------|:---------|
-#'   |game_id                          |integer   |
-#'   |home_team_id                     |integer   |
-#'   |home_team                        |character |
-#'   |away_team_id                     |integer   |
-#'   |away_team                        |character |
-#'   |play_id                          |character |
-#'   |home_score                       |integer   |
-#'   |away_score                       |integer   |
-#'   |period                           |integer   |
-#'   |clock                            |character |
-#'   |wall_clock                       |character |
-#'   |offense_team_id                  |integer   |
-#'   |offense_team                     |character |
-#'   |down                             |integer   |
-#'   |distance                         |integer   |
-#'   |yards_to_goal                    |integer   |
-#'   |yards_gained                     |integer   |
-#'   |play_type_id                     |integer   |
-#'   |play_type                        |character |
-#'   |ppa                              |numeric   |
-#'   |garbage_time                     |logical   |
-#'   |success                          |logical   |
-#'   |rush_pass                        |character |
-#'   |down_type                        |character |
-#'   |play_text                        |character |
-#'   |drive_id                         |character |
-#'   |drive_offense_id                 |integer   |
-#'   |drive_offense_team               |character |
-#'   |drive_defense_id                 |integer   |
-#'   |drive_defense_team               |character |
-#'   |drive_play_count                 |integer   |
-#'   |drive_yards_gained               |integer   |
-#'   |drive_start_period               |integer   |
-#'   |drive_start_clock                |character |
-#'   |drive_start_yards_to_goal        |integer   |
-#'   |drive_end_period                 |integer   |
-#'   |drive_end_clock                  |character |
-#'   |drive_end_yards_to_goal          |integer   |
-#'   |drive_duration                   |character |
-#'   |drive_scoring_opportunity        |logical   |
-#'   |drive_result                     |character |
-#'   |drive_points_gained              |integer   |
-#'   |current_clock                    |character |
-#'   |current_possession               |character |
-#'   |home_line_scores_q1              |integer   |
-#'   |home_line_scores_q2              |integer   |
-#'   |home_line_scores_q3              |integer   |
-#'   |home_line_scores_q4              |integer   |
-#'   |home_points                      |integer   |
-#'   |home_drives                      |integer   |
-#'   |home_scoring_opportunities       |integer   |
-#'   |home_points_per_opportunity      |numeric   |
-#'   |home_plays                       |integer   |
-#'   |home_line_yards                  |numeric   |
-#'   |home_line_yards_per_rush         |numeric   |
-#'   |home_second_level_yards          |integer   |
-#'   |home_second_level_yards_per_rush |numeric   |
-#'   |home_open_field_yards            |integer   |
-#'   |home_open_field_yards_per_rush   |numeric   |
-#'   |home_ppa_per_play                |numeric   |
-#'   |home_total_ppa                   |numeric   |
-#'   |home_passing_ppa                 |numeric   |
-#'   |home_ppa_per_pass                |numeric   |
-#'   |home_rushing_ppa                 |numeric   |
-#'   |home_ppa_per_rush                |numeric   |
-#'   |home_success_rate                |numeric   |
-#'   |home_standard_down_success_rate  |numeric   |
-#'   |home_passing_down_success_rate   |numeric   |
-#'   |home_explosiveness               |numeric   |
-#'   |away_line_scores_q1              |integer   |
-#'   |away_line_scores_q2              |integer   |
-#'   |away_line_scores_q3              |integer   |
-#'   |away_line_scores_q4              |integer   |
-#'   |away_points                      |integer   |
-#'   |away_drives                      |integer   |
-#'   |away_scoring_opportunities       |integer   |
-#'   |away_points_per_opportunity      |numeric   |
-#'   |away_plays                       |integer   |
-#'   |away_line_yards                  |numeric   |
-#'   |away_line_yards_per_rush         |numeric   |
-#'   |away_second_level_yards          |integer   |
-#'   |away_second_level_yards_per_rush |numeric   |
-#'   |away_open_field_yards            |integer   |
-#'   |away_open_field_yards_per_rush   |numeric   |
-#'   |away_ppa_per_play                |numeric   |
-#'   |away_total_ppa                   |numeric   |
-#'   |away_passing_ppa                 |numeric   |
-#'   |away_ppa_per_pass                |numeric   |
-#'   |away_rushing_ppa                 |numeric   |
-#'   |away_ppa_per_rush                |numeric   |
-#'   |away_success_rate                |numeric   |
-#'   |away_standard_down_success_rate  |numeric   |
-#'   |away_passing_down_success_rate   |numeric   |
-#'   |away_explosiveness               |numeric   |
+#'  |col_name                         |types     |
+#'  |:--------------------------------|:---------|
+#'  |game_id                          |integer   |
+#'  |home_team_id                     |integer   |
+#'  |home_team                        |character |
+#'  |away_team_id                     |integer   |
+#'  |away_team                        |character |
+#'  |play_id                          |character |
+#'  |home_score                       |integer   |
+#'  |away_score                       |integer   |
+#'  |period                           |integer   |
+#'  |clock                            |character |
+#'  |wall_clock                       |character |
+#'  |offense_team_id                  |integer   |
+#'  |offense_team                     |character |
+#'  |down                             |integer   |
+#'  |distance                         |integer   |
+#'  |yards_to_goal                    |integer   |
+#'  |yards_gained                     |integer   |
+#'  |play_type_id                     |integer   |
+#'  |play_type                        |character |
+#'  |ppa                              |numeric   |
+#'  |garbage_time                     |logical   |
+#'  |success                          |logical   |
+#'  |rush_pass                        |character |
+#'  |down_type                        |character |
+#'  |play_text                        |character |
+#'  |drive_id                         |character |
+#'  |drive_offense_id                 |integer   |
+#'  |drive_offense_team               |character |
+#'  |drive_defense_id                 |integer   |
+#'  |drive_defense_team               |character |
+#'  |drive_play_count                 |integer   |
+#'  |drive_yards_gained               |integer   |
+#'  |drive_start_period               |integer   |
+#'  |drive_start_clock                |character |
+#'  |drive_start_yards_to_goal        |integer   |
+#'  |drive_end_period                 |integer   |
+#'  |drive_end_clock                  |character |
+#'  |drive_end_yards_to_goal          |integer   |
+#'  |drive_duration                   |character |
+#'  |drive_scoring_opportunity        |logical   |
+#'  |drive_result                     |character |
+#'  |drive_points_gained              |integer   |
+#'  |current_clock                    |character |
+#'  |current_possession               |character |
+#'  |home_line_scores_q1              |integer   |
+#'  |home_line_scores_q2              |integer   |
+#'  |home_line_scores_q3              |integer   |
+#'  |home_line_scores_q4              |integer   |
+#'  |home_points                      |integer   |
+#'  |home_drives                      |integer   |
+#'  |home_scoring_opportunities       |integer   |
+#'  |home_points_per_opportunity      |numeric   |
+#'  |home_average_start_yard_line     |numeric   |
+#'  |home_plays                       |integer   |
+#'  |home_line_yards                  |numeric   |
+#'  |home_line_yards_per_rush         |numeric   |
+#'  |home_second_level_yards          |integer   |
+#'  |home_second_level_yards_per_rush |numeric   |
+#'  |home_open_field_yards            |integer   |
+#'  |home_open_field_yards_per_rush   |numeric   |
+#'  |home_ppa_per_play                |numeric   |
+#'  |home_total_ppa                   |numeric   |
+#'  |home_passing_ppa                 |numeric   |
+#'  |home_ppa_per_pass                |numeric   |
+#'  |home_rushing_ppa                 |numeric   |
+#'  |home_ppa_per_rush                |numeric   |
+#'  |home_success_rate                |numeric   |
+#'  |home_standard_down_success_rate  |numeric   |
+#'  |home_passing_down_success_rate   |numeric   |
+#'  |home_explosiveness               |numeric   |
+#'  |home_deserve_to_win              |numeric   |
+#'  |away_line_scores_q1              |integer   |
+#'  |away_line_scores_q2              |integer   |
+#'  |away_line_scores_q3              |integer   |
+#'  |away_line_scores_q4              |integer   |
+#'  |away_points                      |integer   |
+#'  |away_drives                      |integer   |
+#'  |away_scoring_opportunities       |integer   |
+#'  |away_points_per_opportunity      |numeric   |
+#'  |away_average_start_yard_line     |numeric   |
+#'  |away_plays                       |integer   |
+#'  |away_line_yards                  |numeric   |
+#'  |away_line_yards_per_rush         |numeric   |
+#'  |away_second_level_yards          |integer   |
+#'  |away_second_level_yards_per_rush |numeric   |
+#'  |away_open_field_yards            |integer   |
+#'  |away_open_field_yards_per_rush   |numeric   |
+#'  |away_ppa_per_play                |numeric   |
+#'  |away_total_ppa                   |numeric   |
+#'  |away_passing_ppa                 |numeric   |
+#'  |away_ppa_per_pass                |numeric   |
+#'  |away_rushing_ppa                 |numeric   |
+#'  |away_ppa_per_rush                |numeric   |
+#'  |away_success_rate                |numeric   |
+#'  |away_standard_down_success_rate  |numeric   |
+#'  |away_passing_down_success_rate   |numeric   |
+#'  |away_explosiveness               |numeric   |
+#'  |away_deserve_to_win              |numeric   |
 #'
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET

--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -16,6 +16,7 @@
 #'   \item{5. `kickoffs`:}{Calculate ep_before for kickoffs as if the pre-play assumption is a touchback.}
 #'   \item{6. `wpa_prep`:}{Prep variables for WPA.}
 #' }
+#' @return play_df with  EPA variables added
 #' @keywords internal
 #' @importFrom stats na.omit
 #' @importFrom stats predict
@@ -476,6 +477,7 @@ create_epa <- function(play_df,
 #' @param ep_model (__model__, default `cfbfastR`'s `ep_model`): FG Model to be used for prediction on field goal (FG) attempts in Play-by-Play data.frame
 #' @param fg_mod (__model__, default `cfbfastR`'s `fg_model`): FG Model to be used for prediction on field goal (FG) attempts in Play-by-Play data.frame
 #'
+#' @return Updated expected points probabilities with FG make/miss weighted adjustment
 #' @keywords internal
 #' @importFrom mgcv predict.bam
 #' @importFrom stringr str_detect

--- a/R/helper_pbp_add_yardage.R
+++ b/R/helper_pbp_add_yardage.R
@@ -92,6 +92,11 @@ add_yardage <- function(play_df) {
           stringi::stri_extract_first_regex(.data$play_text, "(?<= for)[^,]+"), "\\d+"
         )),
         .data$pass == 1 &
+          stringr::str_detect(.data$play_text, regex("Yd pass", ignore_case = TRUE)) ~
+          as.numeric(stringr::str_extract(
+            stringi::stri_extract_first_regex(.data$play_text, "(\\d+)\\s+Yd\\s+pass"), "\\d+"
+          )),
+        .data$pass == 1 &
           stringr::str_detect(.data$play_text, regex("pass complete to", ignore_case = TRUE)) ~
           yards_gained, # 2024 has games that don't have yards in the PBP text but do have them in the yards_gained field.
         TRUE ~ NA_real_

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -7,7 +7,7 @@ This is a major release that:
 * Addresses the missing documentation for the `update_cfb_pbp()` function noted in the previous CRAN response.
 * Addresses minor functionality issues in `cfbd_play_stats_player()` function.
 * Updates the `cfbd_*()` functions to use the new College Football Data API v2. 
-* Please ignore submission with SHA: SHA: b11b098637f48f9a1cf5717d0355eeea643d3477
+* Addresses the most recent CRAN comments from the previous submission.
 
 The following functions were added:
   * `cfbd_metrics_fg_ep()`

--- a/man/cfbd_drives.Rd
+++ b/man/cfbd_drives.Rd
@@ -73,8 +73,8 @@ Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC}
 \item{\code{time_seconds_start}:integer.}{Seconds at drive start.}
 \item{\code{time_minutes_end}:integer.}{Minutes at drive end.}
 \item{\code{time_seconds_end}:integer.}{Seconds at drive end.}
-\item{\code{time_minutes_elapsed}:double.}{DEPRECATED Minutes elapsed during drive.}
-\item{\code{time_seconds_elapsed}:integer.}{DEPRECATED Seconds elapsed during drive.}
+\item{\code{time_minutes_elapsed}:double.}{Minutes elapsed during drive.}
+\item{\code{time_seconds_elapsed}:integer.}{Seconds elapsed during drive.}
 }
 }
 \description{
@@ -82,7 +82,7 @@ Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC}
 }
 \examples{
 \donttest{
-  try(cfbd_drives(2018, week = 1, team = "TCU"))
+  try(cfbd_drives(year=2018, week = 1, team = "TCU"))
 
   try(cfbd_drives(2018, team = "Texas A&M", defense_conference = "SEC"))
 }

--- a/man/cfbd_drives.Rd
+++ b/man/cfbd_drives.Rd
@@ -45,7 +45,7 @@ Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC}
 \item{division}{(\emph{String} optional): Division abbreviation - Select a valid division: fbs/fcs/ii/iii}
 }
 \value{
-\code{\link[=cfbd_drives]{cfbd_drives()}} - A data frame with 23 variables as follows:
+\code{\link[=cfbd_drives]{cfbd_drives()}} - A data frame with variables as follows:
 \describe{
 \item{\code{offense}:character.}{Drive offense.}
 \item{\code{offense_conference}:character.}{Drive offense's conference.}

--- a/man/cfbd_live_plays.Rd
+++ b/man/cfbd_live_plays.Rd
@@ -65,6 +65,7 @@ Can be found using the \code{\link[=cfbd_game_info]{cfbd_game_info()}} function}
    home_drives \tab integer \cr
    home_scoring_opportunities \tab integer \cr
    home_points_per_opportunity \tab numeric \cr
+   home_average_start_yard_line \tab numeric \cr
    home_plays \tab integer \cr
    home_line_yards \tab numeric \cr
    home_line_yards_per_rush \tab numeric \cr
@@ -82,6 +83,7 @@ Can be found using the \code{\link[=cfbd_game_info]{cfbd_game_info()}} function}
    home_standard_down_success_rate \tab numeric \cr
    home_passing_down_success_rate \tab numeric \cr
    home_explosiveness \tab numeric \cr
+   home_deserve_to_win \tab numeric \cr
    away_line_scores_q1 \tab integer \cr
    away_line_scores_q2 \tab integer \cr
    away_line_scores_q3 \tab integer \cr
@@ -90,6 +92,7 @@ Can be found using the \code{\link[=cfbd_game_info]{cfbd_game_info()}} function}
    away_drives \tab integer \cr
    away_scoring_opportunities \tab integer \cr
    away_points_per_opportunity \tab numeric \cr
+   away_average_start_yard_line \tab numeric \cr
    away_plays \tab integer \cr
    away_line_yards \tab numeric \cr
    away_line_yards_per_rush \tab numeric \cr
@@ -107,6 +110,7 @@ Can be found using the \code{\link[=cfbd_game_info]{cfbd_game_info()}} function}
    away_standard_down_success_rate \tab numeric \cr
    away_passing_down_success_rate \tab numeric \cr
    away_explosiveness \tab numeric \cr
+   away_deserve_to_win \tab numeric \cr
 }
 }
 \description{

--- a/man/cfbd_pbp_data.Rd
+++ b/man/cfbd_pbp_data.Rd
@@ -401,8 +401,8 @@ A data frame with 368 variables:\tabular{ll}{
 Extract college football (D-I) play by play Data - for plays
 }
 \details{
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{ # Get play by play data for 2018 regular season week 1
- cfbd_pbp_data(year = 2024, week = 1, season_type = 'regular', epa_wpa = TRUE)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{ # Get play by play data for 2025 regular season week 1
+ cfbd_pbp_data(year = 2025, week = 1, season_type = 'regular', epa_wpa = TRUE)
 }\if{html}{\out{</div>}}
 }
 \seealso{

--- a/man/cfbd_play_stats_player.Rd
+++ b/man/cfbd_play_stats_player.Rd
@@ -108,8 +108,8 @@ Can be found using the \code{\link[=cfbd_play_stats_types]{cfbd_play_stats_types
 }
 \examples{
 \donttest{
-  try(cfbd_play_stats_player(game_id = 401110722))
-  try(cfbd_play_stats_player(year = 2023, week = 1))
+  try(cfbd_play_stats_player(game_id = 401628414))
+  try(cfbd_play_stats_player(year = 2025, week = 1))
 }
 }
 \seealso{

--- a/man/create_epa.Rd
+++ b/man/create_epa.Rd
@@ -22,6 +22,11 @@ epa_fg_probs(dat, current_probs, ep_model, fg_mod)
 
 \item{fg_mod}{(\strong{model}, default \code{cfbfastR}'s \code{fg_model}): FG Model to be used for prediction on field goal (FG) attempts in Play-by-Play data.frame}
 }
+\value{
+play_df with  EPA variables added
+
+Updated expected points probabilities with FG make/miss weighted adjustment
+}
 \description{
 Adds Expected Points calculations to Play-by-Play data.frame
 }

--- a/tests/testthat/test-cfbd_drives.R
+++ b/tests/testthat/test-cfbd_drives.R
@@ -14,8 +14,8 @@ test_that("CFB Drives", {
   x <- cfbd_drives(2018, week = 1, team = "TCU")
 
   y <- cfbd_drives(2018, team = "Texas A&M", defense_conference = "SEC")
-  expect_setequal(colnames(x), cols)
-  expect_setequal(colnames(y), cols)
+  expect_in(colnames(x), cols)
+  expect_in(colnames(y), cols)
   expect_s3_class(x, "data.frame")
   expect_s3_class(y, "data.frame")
 })

--- a/tests/testthat/test-cfbd_live_plays.R
+++ b/tests/testthat/test-cfbd_live_plays.R
@@ -53,6 +53,7 @@ cols <- c(
   "home_drives",
   "home_scoring_opportunities",
   "home_points_per_opportunity",
+  "home_average_start_yard_line",
   "home_plays",
   "home_line_yards",
   "home_line_yards_per_rush",
@@ -70,6 +71,7 @@ cols <- c(
   "home_standard_down_success_rate",
   "home_passing_down_success_rate",
   "home_explosiveness",
+  "home_deserve_to_win",
   "away_line_scores_q1",
   "away_line_scores_q2",
   "away_line_scores_q3",
@@ -78,6 +80,7 @@ cols <- c(
   "away_drives",
   "away_scoring_opportunities",
   "away_points_per_opportunity",
+  "away_average_start_yard_line",
   "away_plays",
   "away_line_yards",
   "away_line_yards_per_rush",
@@ -94,7 +97,8 @@ cols <- c(
   "away_success_rate",
   "away_standard_down_success_rate",
   "away_passing_down_success_rate",
-  "away_explosiveness"
+  "away_explosiveness",
+  "away_deserve_to_win"
 )
 
 test_that("CFB Live Plays", {
@@ -102,8 +106,9 @@ test_that("CFB Live Plays", {
   x <- cfbd_live_plays(game_id = 401520182)
 
   y <- cfbd_live_plays(game_id = 401110720)
-  expect_setequal(colnames(x), cols)
-  expect_setequal(colnames(y), cols)
+
+  expect_in(colnames(x), cols)
+  expect_in(colnames(y), cols)
   expect_s3_class(x, "data.frame")
   expect_s3_class(y, "data.frame")
 })

--- a/tests/testthat/test-cfbd_live_scoreboard.R
+++ b/tests/testthat/test-cfbd_live_scoreboard.R
@@ -51,8 +51,8 @@ test_that("CFB Live Scoreboard", {
   x <- cfbd_live_scoreboard(division='fbs', conference = "B12")
 
   y <- cfbd_live_scoreboard(division='fbs')
-  expect_setequal(colnames(x), cols)
-  expect_setequal(colnames(y), cols)
+  expect_in(colnames(x), cols)
+  expect_in(colnames(y), cols)
   expect_s3_class(x, "data.frame")
   expect_s3_class(y, "data.frame")
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved yardage extraction for certain passing plays labeled with “Yd pass.”
  * Added per-game timeout fallback so missing timeout data defaults to 3 per half.

* **New Features**
  * Added public endpoints for metrics, ratings, live scoreboard/plays, and API key info.

* **Documentation**
  * Updated examples, field descriptions, NEWS, and help pages to reflect new columns and behavior.

* **Data/Outputs**
  * Expanded player-level output with team, conference, and clock minutes/seconds; live plays include four new numeric fields.

* **Tests**
  * Relaxed column-name assertions to subset checks across multiple tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->