### PR TITLE
fix(pkgdown): index the cfbd_info family topic

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -399,7 +399,11 @@ reference:
   - subtitle: API Info
     desc: CFBD API key usage and remaining quota
     contents:
-      - '`cfbd_info_usage`'
+      # Prefix match, not the single function: the `@name cfbd_info` family
+      # overview generates its own topic, and pkgdown errors when ANY documented
+      # topic is missing from the index. Listing only `cfbd_info_usage` left
+      # `cfbd_info` unindexed and broke the site build on main.
+      - starts_with("cfbd_info")
   - title: "Fox Sports Data"
   - subtitle: Fox CFB -- Read-only Bifrost wrappers
     desc: Fox Sports college-football endpoints (play-by-play, boxscore, odds, roster, team stats, game log, standings, and statistical leaders)


### PR DESCRIPTION
The docs site build failed on `main` immediately after #129:

```
Error in `build_reference_index()`:
! In _pkgdown.yml, 1 topic missing from index: "cfbd_info".
```

## Cause

#129 added an API-info section listing the function `cfbd_info_usage`, but not
the `@name cfbd_info` family-overview topic, which generates its own `.Rd`.
pkgdown errors when **any** documented topic is absent from the reference index.

The playoffs section added in the same PR used `starts_with("cfbd_playoffs")`,
which covered both its overview and its functions — that inconsistency is why
one broke and the other did not.

## Fix

`starts_with("cfbd_info")`, matching the playoffs pattern. Verified locally by
replicating pkgdown's `check_missing_topics()` against all 195 `man/*.Rd`
topics: `cfbd_info` and `cfbd_info_usage` are both matched.

## Why PR CI could not catch this

`pkgdown.yaml` triggers on **push to main only**, never on pull requests. A
missing index entry is therefore invisible until after merge. Anything adding a
new `@name` family block needs its topic added to `_pkgdown.yml` in the same
change — noted in the commit message for the next person.

## Summary by Sourcery

Ensure pkgdown indexes the full `cfbd_info` topic family to restore successful documentation builds.

Bug Fixes:
- Include the complete `cfbd_info` topic family in the pkgdown reference index so documentation builds no longer fail due to an unindexed overview topic.

Build:
- Update the pkgdown reference configuration to use prefix matching for all `cfbd_info` documentation topics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the API Info reference to include all functions beginning with the `cfbd_info` prefix, rather than only usage-related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->