### PR TITLE
ci(rhub): track r-hub/actions@v1 for node24 runtime compliance

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     # NO NEED TO CHECKOUT HERE
-    - uses: r-hub/actions/setup@v1.7.3
+    - uses: r-hub/actions/setup@v1
       with:
         config: ${{ github.event.inputs.config }}
       id: rhub-setup
@@ -55,16 +55,16 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CFBD_API_KEY: ${{ secrets.CFBD_API_KEY }}
     steps:
-      - uses: r-hub/actions/checkout@v1.7.3
-      - uses: r-hub/actions/platform-info@v1.7.3
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/platform-info@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1.7.3
+      - uses: r-hub/actions/setup-deps@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/run-check@v1.7.3
+      - uses: r-hub/actions/run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
@@ -84,20 +84,20 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CFBD_API_KEY: ${{ secrets.CFBD_API_KEY }}
     steps:
-      - uses: r-hub/actions/checkout@v1.7.3
-      - uses: r-hub/actions/setup-r@v1.7.3
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/setup-r@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/platform-info@v1.7.3
+      - uses: r-hub/actions/platform-info@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1.7.3
+      - uses: r-hub/actions/setup-deps@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/run-check@v1.7.3
+      - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}


### PR DESCRIPTION
Bumps the six `r-hub/actions/*@v1.7.3` pins in `rhub.yaml` to the rolling `@v1` tag. The pinned v1.7.3 composites nest `actions/upload-artifact@v4` (node20 runtime, deprecated by GitHub Actions); the current v1 line nests `upload-artifact@v7` (node24), and the rolling tag matches the canonical rhub workflow template so the runtime stays current automatically.

`R-CMD-check.yaml` and `pkgdown.yaml` are already node24-compliant (`actions/checkout@v5`, rolling `r-lib/actions@v2`) — no changes needed there.

## Summary by Sourcery

Track the rolling R-Hub action v1 release to maintain Node 24 runtime compliance automatically.

Enhancements:
- Update all R-Hub workflow actions to the rolling v1 release to keep the workflow aligned with the current runtime-compatible action versions.

CI:
- Keep the R-Hub workflow aligned with the canonical action versions and current GitHub Actions runtime requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated R-hub workflow actions to use the maintained version 1 tags.
  * Preserved existing workflow steps and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->