### PR TITLE
chore(cran): 3.0.0 submission prep

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -120,7 +120,7 @@ The resolution order is: explicit `proxy =` argument -> `getOption("cfbfastR.pro
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/cfbfastR?style=for-the-badge&logo=x&label=%40cfbfastR&color=eee&link=https%3A%2F%2Fx.com%2FcfbfastR)](https://x.com/cfbfastR)
 [![Twitter Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=x&style=for-the-badge)](https://x.com/SportsDataverse)
 
-[![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/cfbfastR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20cfbfastR&maxAge=2592000)](https://github.com/sportsdataverse/cfbfastR/stargazers/)
+[![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/cfbfastR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20cfbfastR&maxAge=2592000)](https://github.com/sportsdataverse/cfbfastR)
 
 ## **Our Authors**
 
@@ -132,8 +132,7 @@ The resolution order is: explicit `proxy =` argument -> `getOption("cfbfastR.pro
 <a href="https://x.com/akeaswaran" target="blank"><img src="https://img.shields.io/twitter/follow/akeaswaran?color=blue&label=%40akeaswaran&logo=x&style=for-the-badge" alt="@akeaswaran" /></a>
 <a href="https://github.com/akeaswaran" target="blank"><img src="https://img.shields.io/github/followers/akeaswaran?color=eee&logo=Github&style=for-the-badge" alt="@akeaswaran" /></a>
 
--   [Jared Lee](https://x.com/JaredDLee) </br>
-<a href="https://x.com/JaredDLee" target="blank"><img src="https://img.shields.io/twitter/follow/JaredDLee?color=blue&label=%40JaredDLee&logo=x&style=for-the-badge" alt="@JaredDLee" /></a>
+-   Jared Lee </br>
 <a href="https://github.com/Kazink36" target="blank"><img src="https://img.shields.io/github/followers/Kazink36?color=eee&logo=Github&style=for-the-badge" alt="@Kazink36" /></a>
 
 -   [Eric Hess](https://x.com/arbitanalytics) </br>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Follow](https://img.shields.io/twitter/follow/cfbfastR?style=for-the-badge&logo=
 Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=x&style=for-the-badge)](https://x.com/SportsDataverse)
 
 [![GitHub
-stars](https://img.shields.io/github/stars/sportsdataverse/cfbfastR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20cfbfastR&maxAge=2592000)](https://github.com/sportsdataverse/cfbfastR/stargazers/)
+stars](https://img.shields.io/github/stars/sportsdataverse/cfbfastR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20cfbfastR&maxAge=2592000)](https://github.com/sportsdataverse/cfbfastR)
 
 ## **Our Authors**
 
@@ -161,8 +161,7 @@ stars](https://img.shields.io/github/stars/sportsdataverse/cfbfastR.svg?color=ee
     <a href="https://x.com/akeaswaran" target="blank"><img src="https://img.shields.io/twitter/follow/akeaswaran?color=blue&label=%40akeaswaran&logo=x&style=for-the-badge" alt="@akeaswaran" /></a>
     <a href="https://github.com/akeaswaran" target="blank"><img src="https://img.shields.io/github/followers/akeaswaran?color=eee&logo=Github&style=for-the-badge" alt="@akeaswaran" /></a>
 
-  - [Jared Lee](https://x.com/JaredDLee) </br>
-    <a href="https://x.com/JaredDLee" target="blank"><img src="https://img.shields.io/twitter/follow/JaredDLee?color=blue&label=%40JaredDLee&logo=x&style=for-the-badge" alt="@JaredDLee" /></a>
+  - Jared Lee </br>
     <a href="https://github.com/Kazink36" target="blank"><img src="https://img.shields.io/github/followers/Kazink36?color=eee&logo=Github&style=for-the-badge" alt="@Kazink36" /></a>
 
   - [Eric Hess](https://x.com/arbitanalytics) </br>

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -26,9 +26,27 @@ This is a major release (2.2.0 -> 3.0.0; the 2.3.0 development version was renum
 * Documentation migrated to roxygen2 8.1.0; adds a `cph` role to
   `Authors@R` and refreshes the LICENSE year.
 
+## Test environments
+
+* local Windows 10, R 4.6.1 (full suite + `--run-donttest`)
+* GitHub Actions: windows-latest (release), ubuntu-latest (release, oldrel-1)
+* R-hub: linux, windows, macos (R-devel)
+
 ## R CMD check results
 
 0 errors | 0 warnings | 0 notes
+
+(The local Windows run shows one NOTE about a `''NULL''` file in the check
+directory; this is a known artifact of rcmdcheck on Windows in the local
+environment and does not appear on the CI or R-hub platforms.)
+
+## Internet resources
+
+All functions that access internet resources (the CollegeFootballData and
+ESPN APIs, and the pre-built season datasets on GitHub release assets) fail
+gracefully with an informative message and return an empty table when the
+resource is unavailable. Examples for these functions are wrapped in
+`\donttest{try(...)}`.
 
 ## revdepcheck results
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,23 +1,26 @@
-year <- sprintf("%s", sub("-.*", "", meta$Date))
 note <- sprintf("R package version %s", meta$Version)
 
 citHeader("To cite the cfbfastR R package in publications, use:")
 
-citEntry(entry = "Article",
-         author = personList(
-         as.person("Saiem Gilani"),
-         as.person("Akshay Easwaran"),
-         as.person("Jared Lee"),
-         as.person("Eric Hess")),
-         title = "cfbfastR: Access College Football Play by Play Data",
-         url = c("https://cfbfastR.sportsdataverse.org/"),
-         DOI = c("10.32614/CRAN.package.cfbfastR"),
-         journal = "CRAN: Contributed Packages",
-         publisher = "The R Foundation",
-         year = 2021,
-         note = note,
-         textVersion = paste(
-    "Saiem Gilani and Akshay Easwaran and Jared Lee and Eric Hess (2021). cfbfastR: Access College Football Play by Play Data.",
-    "Retrieved from https://cfbfastR.sportsdataverse.org/", "doi: 10.32614/CRAN.package.cfbfastR",  sep=" "
+bibentry(
+  bibtype   = "Article",
+  author    = c(
+    person("Saiem", "Gilani"),
+    person("Akshay", "Easwaran"),
+    person("Jared", "Lee"),
+    person("Eric", "Hess")
+  ),
+  title     = "cfbfastR: Access College Football Play by Play Data",
+  url       = "https://cfbfastR.sportsdataverse.org/",
+  doi       = "10.32614/CRAN.package.cfbfastR",
+  journal   = "CRAN: Contributed Packages",
+  publisher = "The R Foundation",
+  year      = 2021,
+  note      = note,
+  textVersion = paste(
+    "Saiem Gilani and Akshay Easwaran and Jared Lee and Eric Hess (2021).",
+    "cfbfastR: Access College Football Play by Play Data.",
+    "Retrieved from https://cfbfastR.sportsdataverse.org/",
+    "doi: 10.32614/CRAN.package.cfbfastR"
   )
 )


### PR DESCRIPTION
CRAN pre-submission pass for 3.0.0: urlchecker fixes (stargazers badge target, dead x.com links), CITATION modernized to bibentry() (citEntry/personList are deprecated and flagged on CRAN incoming), cran-comments test environments + internet-resources statement. Rd audit: 221/221 exported topics have \value; spell-check hits are sports acronyms; README clean of relative links.

## Summary by Sourcery

Prepare the 3.0.0 release for CRAN submission by correcting documentation links, modernizing citation metadata, and documenting validation results and network-resource handling.

Bug Fixes:
- Remove broken or outdated README links identified during CRAN URL validation.

Enhancements:
- Modernize package citation metadata for current CRAN requirements.

Documentation:
- Update CRAN submission notes with test environments, check results context, and internet-resource behavior.

Chores:
- Prepare the package documentation and metadata for the 3.0.0 CRAN submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub stars badge to link directly to the repository.
  * Simplified the author information by removing an external social-media link and follower badge.
  * Added CRAN submission notes covering test environments, local artifacts, and unavailable internet resources.
  * Modernized the package citation format while preserving existing citation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->