### PR TITLE
fix(cran): clear the HTML-manual NOTE + skip oracle-parity tests on CRAN

### DIFF
--- a/R/load_cfb_datasets.R
+++ b/R/load_cfb_datasets.R
@@ -1022,7 +1022,7 @@ NULL
 #'    |espn_game_id         |integer   |ESPN game id for the crosswalk row. |
 #'    |fox_game_id          |character |Fox Sports game id for the same game. |
 #'    |yahoo_game_id        |character |Yahoo Sports game id for the same game. |
-#'    |yahoo_global_game_id |character |Yahoo's cross-season global game key in ncaaf.g.<number> form, distinct from the date-encoded yahoo_game_id. |
+#'    |yahoo_global_game_id |character |Yahoo's cross-season global game key in `ncaaf.g.NNNN` form, distinct from the date-encoded yahoo_game_id. |
 #'    |home_team            |character | |
 #'    |away_team            |character | |
 #'    |espn_date            |character |Kickoff date as YYYY-MM-DD taken from ESPN's schedule, null on games that matched no ESPN row. |

--- a/man/load_cfb_schedule_crosswalk.Rd
+++ b/man/load_cfb_schedule_crosswalk.Rd
@@ -28,7 +28,7 @@ Returns a \code{cfbfastR_data} tibble.\tabular{lll}{
    espn_game_id \tab integer \tab ESPN game id for the crosswalk row. \cr
    fox_game_id \tab character \tab Fox Sports game id for the same game. \cr
    yahoo_game_id \tab character \tab Yahoo Sports game id for the same game. \cr
-   yahoo_global_game_id \tab character \tab Yahoo's cross-season global game key in ncaaf.g.\if{html}{\out{<number>}} form, distinct from the date-encoded yahoo_game_id. \cr
+   yahoo_global_game_id \tab character \tab Yahoo's cross-season global game key in \code{ncaaf.g.NNNN} form, distinct from the date-encoded yahoo_game_id. \cr
    home_team \tab character \tab  \cr
    away_team \tab character \tab  \cr
    espn_date \tab character \tab Kickoff date as YYYY-MM-DD taken from ESPN's schedule, null on games that matched no ESPN row. \cr

--- a/tests/testthat/test-parity_air_yards.R
+++ b/tests/testthat/test-parity_air_yards.R
@@ -37,6 +37,7 @@ py_form <- function(txt) {
 }
 
 test_that("air yards match sdv-py on every row sdv-py resolves", {
+  testthat::skip_on_cran()
   skip_if_not(file.exists(air_path), "air-yards fixture not generated")
   skip_if_not_installed("arrow")
   x <- replay(air_path, .pbp_add_air_yards_cols)
@@ -49,6 +50,7 @@ test_that("air yards match sdv-py on every row sdv-py resolves", {
 })
 
 test_that("the article form recovers catch points sdv-py drops", {
+  testthat::skip_on_cran()
   skip_if_not(file.exists(air_path), "air-yards fixture not generated")
   skip_if_not_installed("arrow")
   x <- replay(air_path, .pbp_add_air_yards_cols)
@@ -65,6 +67,7 @@ test_that("the article form recovers catch points sdv-py drops", {
 })
 
 test_that("the air-yards oracle is not degenerate", {
+  testthat::skip_on_cran()
   skip_if_not(file.exists(air_path), "air-yards fixture not generated")
   skip_if_not_installed("arrow")
   o <- as.data.frame(arrow::read_parquet(air_path))

--- a/tests/testthat/test-parity_attribution.R
+++ b/tests/testthat/test-parity_attribution.R
@@ -9,6 +9,7 @@
 oracle_path <- testthat::test_path("fixtures", "parity", "attribution_oracle.parquet")
 
 skip_if_no_fixture <- function() {
+  testthat::skip_on_cran()
   testthat::skip_if_not(file.exists(oracle_path), "parity fixtures not generated")
   testthat::skip_if_not_installed("arrow")
 }

--- a/tests/testthat/test-parity_join_participants.R
+++ b/tests/testthat/test-parity_join_participants.R
@@ -16,6 +16,7 @@ oracle_path <- testthat::test_path("fixtures", "parity", "participants_oracle.pa
 parts_path  <- testthat::test_path("fixtures", "parity", "play_participants.parquet")
 
 skip_if_no_fixture <- function() {
+  testthat::skip_on_cran()
   testthat::skip_if_not(file.exists(oracle_path) && file.exists(parts_path),
                         "parity fixtures not generated")
   testthat::skip_if_not_installed("arrow")

--- a/tests/testthat/test-parity_penalty_enforcement.R
+++ b/tests/testthat/test-parity_penalty_enforcement.R
@@ -13,6 +13,7 @@
 fixture_path <- testthat::test_path("fixtures", "parity", "sdvpy_golden.parquet")
 
 skip_if_no_fixture <- function() {
+  testthat::skip_on_cran()
   testthat::skip_if_not(file.exists(fixture_path), "parity golden fixture not generated")
   testthat::skip_if_not_installed("arrow")
 }

--- a/tests/testthat/test-parity_player_ids.R
+++ b/tests/testthat/test-parity_player_ids.R
@@ -10,6 +10,7 @@ roster_path  <- testthat::test_path("fixtures", "parity", "game_rosters.parquet"
 box_path     <- testthat::test_path("fixtures", "parity", "game_boxscores.parquet")
 
 skip_if_no_fixture <- function() {
+  testthat::skip_on_cran()
   testthat::skip_if_not(file.exists(fixture_path) && file.exists(roster_path),
                         "parity fixtures not generated")
   testthat::skip_if_not_installed("arrow")

--- a/tests/testthat/test-pbp_boxscore_parity.R
+++ b/tests/testthat/test-pbp_boxscore_parity.R
@@ -15,6 +15,7 @@ pbp_path <- testthat::test_path("fixtures", "parity", "boxparity_pbp.parquet")
 box_path <- testthat::test_path("fixtures", "parity", "boxparity_box.parquet")
 
 skip_if_no_fixture <- function() {
+  testthat::skip_on_cran()
   testthat::skip_if_not(file.exists(pbp_path) && file.exists(box_path),
                         "boxscore-parity fixtures not generated")
   testthat::skip_if_not_installed("arrow")


### PR DESCRIPTION
Fixes the two findings from the win-builder devel run (https://win-builder.r-project.org/zW6FyGlY0uI4/00check.log):

1. **HTML version of manual NOTE** — a literal `<number>` in the `load_cfb_schedule_crosswalk()` returns table became `\if{html}{\out{<number>}}` and failed HTML validation. Now `ncaaf.g.NNNN` in code markup; the `\out{}` construct is gone from the regenerated Rd.
2. **Test time** — the six sdv-py oracle-parity test files now `skip_on_cran()` via their fixture-gate helpers (`test-parity_player_ids.R` alone was 25s). They validate cross-language parity against committed fixtures, which GH Actions covers on every push. Verified: with `NOT_CRAN=false` the set runs in 1.2s (was ~31s locally; win-builder tests were 63s total), and the tests still execute normally outside CRAN.

## Summary by Sourcery

Resolve CRAN checks by correcting HTML manual output and excluding time-intensive oracle-parity tests from CRAN runs.

Bug Fixes:
- Replace the invalid HTML manual markup for Yahoo global game IDs with valid code-formatted documentation.

Enhancements:
- Skip cross-language oracle-parity tests on CRAN while retaining their normal execution in other environments.

Documentation:
- Update the crosswalk documentation to describe Yahoo global game IDs using valid R documentation formatting.

Tests:
- Configure six fixture-based parity test suites to skip on CRAN, reducing CRAN test time.