### PR TITLE
fix(cran): skip the entire test suite on CRAN

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,13 @@
+## Resubmission
+
+This is a resubmission of 3.0.0. The previous upload failed the incoming
+pretest on Debian because one test read a zstd-compressed parquet fixture,
+which the pretest machine's 'arrow' build does not support. The full test
+suite now skips on CRAN (the tests validate cross-language parity against
+committed fixtures and live APIs, and run on the package's continuous
+integration on every push); on CRAN the suite completes with no test
+executed.
+
 ## Release summary
 
 This is a major release (2.2.0 -> 3.0.0; the 2.3.0 development version was renumbered and never published) that:

--- a/tests/testthat/test-cfbd_coverage.R
+++ b/tests/testthat/test-cfbd_coverage.R
@@ -45,6 +45,7 @@ test_that("the division filter actually filters", {
 })
 
 test_that("validate_division rejects a value CFBD would silently ignore", {
+  testthat::skip_on_cran()
   # CFBD ignores an unrecognised filter rather than erroring, so validating
   # locally is the only way a typo surfaces at all.
   expect_error(validate_division("d1"))
@@ -56,6 +57,7 @@ test_that("validate_division rejects a value CFBD would silently ignore", {
 })
 
 test_that("cfbd_rankings only accepts the poll value CFBD implements", {
+  testthat::skip_on_cran()
   # The spec's RankingPoll enum has exactly one member; every other value
   # returns HTTP 400, so this fails locally with a usable message instead.
   expect_error(cfbd_rankings(2024, poll = "AP Top 25"))

--- a/tests/testthat/test-espn_cfb_team_coaches.R
+++ b/tests/testthat/test-espn_cfb_team_coaches.R
@@ -72,6 +72,7 @@ test_that("the current season does not warn", {
 })
 
 test_that("year is validated before it is compared", {
+  testthat::skip_on_cran()
   # Offline: these abort during validation, so no network call is made.
   # `year != most_recent_cfb_season()` yields NA for NA and length > 1 for a
   # vector; either makes `if` raise a raw R error rather than a cli message, so

--- a/tests/testthat/test-espn_http_headers.R
+++ b/tests/testthat/test-espn_http_headers.R
@@ -19,6 +19,7 @@
 ### the moment someone re-adds the header rather than months later in a release.
 
 test_that("no site.api.espn.com caller sends a User-Agent", {
+  testthat::skip_on_cran()
   r_dir <- testthat::test_path("..", "..", "R")
   skip_if_not(dir.exists(r_dir), "package sources not available")
 
@@ -50,6 +51,7 @@ test_that("no site.api.espn.com caller sends a User-Agent", {
 })
 
 test_that("the sidecar fetch does not send a User-Agent either", {
+  testthat::skip_on_cran()
   # cdn.espn.com answers 200 with an EMPTY body when a browser UA is sent, which
   # is worse than a 403: nothing raises, the JSON parse just yields nothing.
   # R CMD check runs the suite against the INSTALLED package, where R/*.R does

--- a/tests/testthat/test-parity_air_yards.R
+++ b/tests/testthat/test-parity_air_yards.R
@@ -87,6 +87,7 @@ test_that("the air-yards oracle is not degenerate", {
 })
 
 test_that("the catch point is sided against the right team", {
+  testthat::skip_on_cran()
   # "caught at HOM35" with the possessing team owning that side means 65 yards
   # still to the endzone; the same text on the DEFENDING team's side means 35.
   # Getting this backwards silently mirrors every air-yards value about midfield.
@@ -107,6 +108,7 @@ test_that("the catch point is sided against the right team", {
 })
 
 test_that("an abbreviation ESPN spells differently still resolves", {
+  testthat::skip_on_cran()
   # ESPN ships two abbreviation forms for some teams -- "caught at BUF35" in the
   # text while the payload carries "BUFF". Prefix-tolerant matching is what
   # keeps those plays from silently losing their air yards.
@@ -121,6 +123,7 @@ test_that("an abbreviation ESPN spells differently still resolves", {
 })
 
 test_that("yards after catch is computed for completions only", {
+  testthat::skip_on_cran()
   # An incompletion has a catch point but no yards after it; subtracting there
   # would invent a number.
   df <- data.frame(
@@ -138,6 +141,7 @@ test_that("yards after catch is computed for completions only", {
 })
 
 test_that("no catch text yields NA, not zero", {
+  testthat::skip_on_cran()
   df <- data.frame(
     play_text = "J. Smith run for 5 yards",
     pos_team_id = "1", def_pos_team_id = "2", home_team_id = "1",
@@ -151,6 +155,7 @@ test_that("no catch text yields NA, not zero", {
 })
 
 test_that("pass depth, direction and the hurry flag match sdv-py", {
+  testthat::skip_on_cran()
   skip_if_not(file.exists(dir_path), "direction fixture not generated")
   skip_if_not_installed("arrow")
   x <- replay(dir_path, .pbp_add_pass_direction_cols)
@@ -164,6 +169,7 @@ test_that("pass depth, direction and the hurry flag match sdv-py", {
 })
 
 test_that("depth and direction matching is case-sensitive on purpose", {
+  testthat::skip_on_cran()
   # ESPN writes these tokens lowercase mid-sentence. Folding case would let a
   # capitalised player or team name match -- "Wright" contains no whitespace
   # boundary issue, but " Deep " as a proper noun does.
@@ -178,6 +184,7 @@ test_that("depth and direction matching is case-sensitive on purpose", {
 })
 
 test_that("the flags gate which direction column is filled", {
+  testthat::skip_on_cran()
   # One regex feeds both pass_direction and rush_direction; only the play's own
   # flag decides which one receives it.
   df <- data.frame(
@@ -190,6 +197,7 @@ test_that("the flags gate which direction column is filled", {
 })
 
 test_that("a direction at end-of-string does not match", {
+  testthat::skip_on_cran()
   # The pattern requires whitespace on BOTH sides, so a truncated description
   # ending in the direction word yields NA. That is sdv-py's behaviour and it is
   # pinned here because it looks like an off-by-one and is not: real ESPN text
@@ -202,6 +210,7 @@ test_that("a direction at end-of-string does not match", {
 })
 
 test_that("qb_hurry is FALSE on null text, never NA", {
+  testthat::skip_on_cran()
   # It stays a clean boolean so downstream filters and models do not have to
   # special-case a missing description.
   df <- data.frame(play_text = c("QB hurried by #55 T. Jones", "run for 3", NA),

--- a/tests/testthat/test-parity_attribution.R
+++ b/tests/testthat/test-parity_attribution.R
@@ -32,6 +32,7 @@ differs <- function(a, b) {
 }
 
 test_that("team attribution matches sdv-py", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   x <- attributed()
 
@@ -48,6 +49,7 @@ test_that("team attribution matches sdv-py", {
 })
 
 test_that("the fumble and recovery chain matches sdv-py", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   x <- attributed()
 
@@ -59,6 +61,7 @@ test_that("the fumble and recovery chain matches sdv-py", {
 })
 
 test_that("the per-side turnover flags match sdv-py", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   x <- attributed()
 
@@ -75,6 +78,7 @@ test_that("the per-side turnover flags match sdv-py", {
 })
 
 test_that("penalty attribution matches sdv-py", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   x <- attributed()
 
@@ -85,6 +89,7 @@ test_that("penalty attribution matches sdv-py", {
 })
 
 test_that("the oracle exercises every branch it claims to", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   o <- as.data.frame(arrow::read_parquet(oracle_path))
 
@@ -109,6 +114,7 @@ test_that("the oracle exercises every branch it claims to", {
 })
 
 test_that("the derived flags reproduce the oracle exactly", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   o <- as.data.frame(arrow::read_parquet(oracle_path))
   inp <- setdiff(names(o), c(grep("__out$", names(o), value = TRUE), "fixture_game_id"))
@@ -136,6 +142,7 @@ test_that("the derived flags reproduce the oracle exactly", {
 })
 
 test_that("an overturned play does not count its reversed fumble", {
+  testthat::skip_on_cran()
   # ESPN appends the REVERSED description after CALL OVERTURNED. Parsing
   # recoveries out of that clause counts a reversed fumble as a real turnover.
   df <- data.frame(
@@ -162,6 +169,7 @@ test_that("an overturned play does not count its reversed fumble", {
 })
 
 test_that("both teams can register a turnover on one play", {
+  testthat::skip_on_cran()
   # Offense fumbles (defense recovers), defense fumbles on the return (offense
   # recovers). A single-flag model cannot express this.
   df <- data.frame(
@@ -182,6 +190,7 @@ test_that("both teams can register a turnover on one play", {
 })
 
 test_that("a blocked punt stays out of is_turnover", {
+  testthat::skip_on_cran()
   # ESPN's official box counts only giveaways. Folding blocked kicks into
   # is_turnover breaks the reconciliation against it while looking more complete.
   df <- data.frame(
@@ -200,6 +209,7 @@ test_that("a blocked punt stays out of is_turnover", {
 })
 
 test_that("the special-teams flip credits the right side", {
+  testthat::skip_on_cran()
   df <- data.frame(
     pos_team_id = c("1", "1"), def_pos_team_id = c("2", "2"),
     play_text = c("Kickoff", "Punt"), play_type = c("Kickoff", "Punt"),

--- a/tests/testthat/test-parity_join_participants.R
+++ b/tests/testthat/test-parity_join_participants.R
@@ -40,6 +40,7 @@ joined <- function() {
 differs <- function(a, b) !((is.na(a) & is.na(b)) | (!is.na(a) & !is.na(b) & a == b))
 
 test_that("participant names coalesce exactly as sdv-py does", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   x <- joined()
 
@@ -53,6 +54,7 @@ test_that("participant names coalesce exactly as sdv-py does", {
 })
 
 test_that("the stage actually rewrites names (the oracle is not a no-op)", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   x <- joined()
 
@@ -66,6 +68,7 @@ test_that("the stage actually rewrites names (the oracle is not a no-op)", {
 })
 
 test_that("row count and column set survive the join", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   o <- as.data.frame(arrow::read_parquet(oracle_path))
   p <- as.data.frame(arrow::read_parquet(parts_path))
@@ -82,6 +85,7 @@ test_that("row count and column set survive the join", {
 })
 
 test_that("a duplicated participant row cannot fan out the plays", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   p <- as.data.frame(arrow::read_parquet(parts_path))
   gid <- p$fixture_game_id[1]
@@ -95,6 +99,7 @@ test_that("a duplicated participant row cannot fan out the plays", {
 })
 
 test_that("no participants leaves the frame untouched", {
+  testthat::skip_on_cran()
   df <- data.frame(id = c("1", "2"),
                    rusher_player_name = c("A. Smith", NA_character_),
                    stringsAsFactors = FALSE)
@@ -104,6 +109,7 @@ test_that("no participants leaves the frame untouched", {
 })
 
 test_that("return roles clean up but never introduce a name", {
+  testthat::skip_on_cran()
   df <- data.frame(
     id = c("10", "11"),
     punt_return_player_name    = c("J. Smth", NA_character_),
@@ -122,6 +128,7 @@ test_that("return roles clean up but never introduce a name", {
 })
 
 test_that("the pass defender is routed to the interceptor on interceptions", {
+  testthat::skip_on_cran()
   df <- data.frame(
     id  = c("20", "21"),
     int = c(1, 0),
@@ -142,6 +149,7 @@ test_that("the pass defender is routed to the interceptor on interceptions", {
 })
 
 test_that("an 18-digit play id joins exactly", {
+  testthat::skip_on_cran()
   # ESPN play ids run past 2^53, so a numeric join key silently collides
   # neighbouring plays. Two ids that differ only in the last digit must not
   # cross-match.

--- a/tests/testthat/test-parity_penalty_enforcement.R
+++ b/tests/testthat/test-parity_penalty_enforcement.R
@@ -53,6 +53,7 @@ expect_col_parity <- function(m, nm) {
 }
 
 test_that("penalty flags match sdv-py on the 60-game oracle", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   m <- paired(read_golden())
 
@@ -64,6 +65,7 @@ test_that("penalty flags match sdv-py on the 60-game oracle", {
 })
 
 test_that("penalty enforcement classes match sdv-py", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   m <- paired(read_golden())
 
@@ -74,6 +76,7 @@ test_that("penalty enforcement classes match sdv-py", {
 })
 
 test_that("an unknown enforcement class stays NA rather than collapsing to FALSE", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   m <- paired(read_golden())
 
@@ -85,6 +88,7 @@ test_that("an unknown enforcement class stays NA rather than collapsing to FALSE
 })
 
 test_that("every fixture season is represented in the oracle", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   g <- read_golden()
   expect_setequal(

--- a/tests/testthat/test-parity_player_ids.R
+++ b/tests/testthat/test-parity_player_ids.R
@@ -69,6 +69,7 @@ count_mismatches <- function(x) {
 differs <- function(a, b) !((is.na(a) & is.na(b)) | (!is.na(a) & !is.na(b) & a == b))
 
 test_that("player ids resolve to sdv-py's athlete ids", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   m <- count_mismatches(resolved())
 
@@ -88,6 +89,7 @@ test_that("player ids resolve to sdv-py's athlete ids", {
 })
 
 test_that("the box score is what closes the gap, not the roster alone", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   skip_if_not(file.exists(box_path), "box-score fixture not generated")
 
@@ -102,6 +104,7 @@ test_that("the box score is what closes the gap, not the roster alone", {
 })
 
 test_that("a bare Team sentinel is never fuzzy-matched to a player", {
+  testthat::skip_on_cran()
   # "Team" with no play-text or box-score provenance must not resolve: reaching
   # the surname tier returns whichever roster player the fallback lands on -- a
   # wrong athlete on a play that had no individual ball carrier.
@@ -117,6 +120,7 @@ test_that("a bare Team sentinel is never fuzzy-matched to a player", {
 })
 
 test_that("the play-text sentinel resolves to the box score's team entry", {
+  testthat::skip_on_cran()
   # ESPN writes "TEAM" in the play text and " Team" in the box score, and
   # sdv-py credits the box entry's negative id. Both must normalise to the same
   # key while a bare "Team" stays blanked -- see .norm_player_name, where the
@@ -130,6 +134,7 @@ test_that("the play-text sentinel resolves to the box score's team entry", {
 })
 
 test_that("no roster still yields the id columns, all NA", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   g <- as.data.frame(arrow::read_parquet(fixture_path))
   idc <- grep("_player_id$", names(g), value = TRUE)
@@ -143,6 +148,7 @@ test_that("no roster still yields the id columns, all NA", {
 })
 
 test_that("a trailing (TEAM) suffix is stripped from captured names", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   df <- data.frame(
     rusher_player_name = c("Bryan Randall (VT)", "Matt Ryan (BC)", "Plain Name"),

--- a/tests/testthat/test-pbp_boxscore_parity.R
+++ b/tests/testthat/test-pbp_boxscore_parity.R
@@ -35,6 +35,7 @@ measured <- function() {
 }
 
 test_that("the aggregation encodes the three NCAA conventions", {
+  testthat::skip_on_cran()
   # These are the definitions that were PROVEN against the box, and two are the
   # opposite of the NFL's. Getting any of them wrong shifts a whole stat.
   # The last row gives B a possession of its own. That is not padding: the
@@ -72,6 +73,7 @@ test_that("the aggregation encodes the three NCAA conventions", {
 })
 
 test_that("turnovers are interceptions plus fumbles lost", {
+  testthat::skip_on_cran()
   pbp <- data.frame(
     game_id = "G1", season = 2024, pos_team_id = "A", def_pos_team_id = "B",
     rush = 0, pass = c(1, 1, 0), completion = 0, sack = 0,
@@ -86,6 +88,7 @@ test_that("turnovers are interceptions plus fumbles lost", {
 })
 
 test_that("an empty frame yields the documented schema, not an error", {
+  testthat::skip_on_cran()
   a <- .pbp_boxscore_aggregate(data.frame())
   expect_s3_class(a, "data.frame")
   expect_equal(nrow(a), 0L)
@@ -93,6 +96,7 @@ test_that("an empty frame yields the documented schema, not an error", {
 })
 
 test_that("parity against ESPN's own box clears the measured floors", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   m <- measured()
   expect_gt(nrow(m), 0L)
@@ -112,6 +116,7 @@ test_that("parity against ESPN's own box clears the measured floors", {
 })
 
 test_that("the parity measurement is not silently grading a subset", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   m <- measured()
   # A null join key is removed by the join, which SHIFTS the measured rate with
@@ -122,6 +127,7 @@ test_that("the parity measurement is not silently grading a subset", {
 })
 
 test_that("the aggregate covers every team-game that has offensive plays", {
+  testthat::skip_on_cran()
   skip_if_no_fixture()
   p <- as.data.frame(arrow::read_parquet(pbp_path))
   b <- as.data.frame(arrow::read_parquet(box_path))

--- a/tests/testthat/test-pbp_engine_switch.R
+++ b/tests/testthat/test-pbp_engine_switch.R
@@ -5,6 +5,7 @@
 ### which already asserts v2 reproduces the legacy frames column-for-column.
 
 test_that("engine resolution follows per-call > option > default", {
+  testthat::skip_on_cran()
   withr::local_options(list(cfbfastR.pbp_engine = NULL))
   # v2 is the default as of this release; `legacy` is the escape hatch.
   expect_equal(.pbp_engine(NULL), "v2")
@@ -19,6 +20,7 @@ test_that("engine resolution follows per-call > option > default", {
 })
 
 test_that("auto tracks whatever this release considers current", {
+  testthat::skip_on_cran()
   withr::local_options(list(cfbfastR.pbp_engine = NULL))
   # The point of "auto": a caller who writes it now is carried forward by the
   # release that flips the default, instead of editing their code a second time.
@@ -26,12 +28,14 @@ test_that("auto tracks whatever this release considers current", {
 })
 
 test_that("an unknown engine aborts with an actionable message", {
+  testthat::skip_on_cran()
   expect_error(.pbp_engine("turbo"), "must be one of")
   expect_error(.pbp_engine(c("v2", "legacy")), "must be one of")
   expect_error(.pbp_engine(2L), "must be one of")
 })
 
 test_that("the legacy nudge fires once per session, not once per call", {
+  testthat::skip_on_cran()
   # A season sweep calls the legacy entry point per week. A message on each is
   # noise the user learns to filter, which is how a real deprecation notice ends
   # up missed.
@@ -42,6 +46,7 @@ test_that("the legacy nudge fires once per session, not once per call", {
 })
 
 test_that("both legacy entry points accept the engine argument", {
+  testthat::skip_on_cran()
   expect_true("engine" %in% names(formals(cfbd_pbp_data)))
   expect_true("engine" %in% names(formals(espn_cfb_pbp)))
   # output must be reachable from the legacy name too, or delegating callers

--- a/tests/testthat/test-pbp_equivalence.R
+++ b/tests/testthat/test-pbp_equivalence.R
@@ -250,6 +250,7 @@ test_that("cfbd_pbp_data_v2(epa_wpa = TRUE) matches cfbd_pbp_data(epa_wpa = TRUE
 })
 
 test_that("allow-list rationales are present for every allowed-to-differ column", {
+  testthat::skip_on_cran()
   # Documentation guardrail: every allow-list entry must carry a rationale.
   al <- .eq_allow_list()
   expect_true(length(al) > 0L)
@@ -266,6 +267,7 @@ test_that("allow-list rationales are present for every allowed-to-differ column"
 # ---------------------------------------------------------------------------
 
 test_that(".pbp_apply_output_schema(): structural tier monotonicity (synthetic frame)", {
+  testthat::skip_on_cran()
   # Always runs -- no live API. Confirms the subset chain and value equality
   # by feeding a constructed frame through all three tiers.
   df <- data.frame(

--- a/tests/testthat/test-pbp_output_schema.R
+++ b/tests/testthat/test-pbp_output_schema.R
@@ -1,4 +1,5 @@
 test_that(".pbp_output_order is a non-empty unique character vector", {
+  testthat::skip_on_cran()
   cols <- cfbfastR:::.pbp_output_order
 
   expect_type(cols, "character")
@@ -12,6 +13,7 @@ test_that(".pbp_output_order is a non-empty unique character vector", {
 })
 
 test_that(".pbp_apply_output_schema() reorders known cols and trails unknowns", {
+  testthat::skip_on_cran()
   df <- data.frame(
     extra_col_a  = 1,
     EPA          = 0.1,
@@ -32,6 +34,7 @@ test_that(".pbp_apply_output_schema() reorders known cols and trails unknowns", 
 })
 
 test_that(".pbp_apply_output_schema() drops the documented player-name aliases", {
+  testthat::skip_on_cran()
   df <- data.frame(
     id_play                       = "x",
     punt_return_player            = NA,
@@ -56,6 +59,7 @@ test_that(".pbp_apply_output_schema() drops the documented player-name aliases",
 })
 
 test_that(".pbp_apply_output_schema(output = 'default') drops the tier-1 sets", {
+  testthat::skip_on_cran()
   df <- data.frame(
     id_play              = "x",
     # lag/lead representative
@@ -97,6 +101,7 @@ test_that(".pbp_apply_output_schema(output = 'default') drops the tier-1 sets", 
 })
 
 test_that(".pbp_apply_output_schema(output = 'lean') also drops the WPA scratchpad", {
+  testthat::skip_on_cran()
   df <- data.frame(
     id_play     = "x",
     wpa_base    = 0.01,
@@ -118,6 +123,7 @@ test_that(".pbp_apply_output_schema(output = 'lean') also drops the WPA scratchp
 })
 
 test_that(".pbp_apply_output_schema(output = 'full') drops only player aliases", {
+  testthat::skip_on_cran()
   df <- data.frame(
     id_play              = "x",
     lag_play_type        = NA,
@@ -137,6 +143,7 @@ test_that(".pbp_apply_output_schema(output = 'full') drops only player aliases",
 })
 
 test_that(".pbp_apply_output_schema() defaults to 'default' and rejects unknown values", {
+  testthat::skip_on_cran()
   df <- data.frame(id_play = "x", sack_vec = 0, stringsAsFactors = FALSE)
 
   # Default of `output` is "default"
@@ -148,6 +155,7 @@ test_that(".pbp_apply_output_schema() defaults to 'default' and rejects unknown 
 })
 
 test_that("kept-with-rationale columns are absent from the drop vectors", {
+  testthat::skip_on_cran()
   # Documentation guardrail: orig_play_type and pts_scored are intentionally
   # NOT dropped in default/lean. Make sure they never sneak into the vectors.
   expect_false("orig_play_type" %in% cfbfastR:::.pbp_drop_redundant)

--- a/tests/testthat/test-pbp_sidecar.R
+++ b/tests/testthat/test-pbp_sidecar.R
@@ -7,6 +7,7 @@
 ### gated; what matters here is that the parsing and the degradation are right.
 
 test_that("a missing sidecar degrades to empty frames, never an error", {
+  testthat::skip_on_cran()
   s <- .espn_cfb_pbp_sidecar(NULL)
   # An unavailable sidecar must mean "no extra identity source", so a game whose
   # payload 404s still returns play-by-play instead of aborting the call.
@@ -19,6 +20,7 @@ test_that("a missing sidecar degrades to empty frames, never an error", {
 })
 
 test_that("participant names expand from short to full form by id", {
+  testthat::skip_on_cran()
   parts <- data.frame(
     play_id                = c("1", "2", "3"),
     rusher_player_name     = c("J. Mitchell", "K. Cumby", "Z. Unknown"),
@@ -43,6 +45,7 @@ test_that("participant names expand from short to full form by id", {
 })
 
 test_that("expansion is a no-op without a lookup or without id columns", {
+  testthat::skip_on_cran()
   parts <- data.frame(play_id = "1", rusher_player_name = "J. Mitchell",
                       stringsAsFactors = FALSE)
   empty <- data.frame(athlete_id = character(0), display_name = character(0),
@@ -62,6 +65,7 @@ test_that("expansion is a no-op without a lookup or without id columns", {
 })
 
 test_that("the box-score records are shaped for the id resolver", {
+  testthat::skip_on_cran()
   # `.pbp_attach_player_ids()` reads a roster by these three column names, so a
   # rename upstream would silently disable the second identity source rather
   # than fail.
@@ -71,6 +75,7 @@ test_that("the box-score records are shaped for the id resolver", {
 })
 
 test_that("the sidecar helper is registered for caching", {
+  testthat::skip_on_cran()
   # It is fetched twice per espn_cfb_pbp_v2() call (names, then identity
   # records) and once per game in a season sweep. Falling out of this list turns
   # one request into many without failing anything.
@@ -82,6 +87,7 @@ test_that("the sidecar helper is registered for caching", {
 })
 
 test_that("resolve_names rejects a non-scalar-logical", {
+  testthat::skip_on_cran()
   expect_error(espn_cfb_pbp_v2(1, resolve_names = "yes"), "must be a single")
   expect_error(espn_cfb_pbp_v2(1, resolve_names = NA), "must be a single")
   expect_error(espn_cfb_pbp_v2(1, resolve_names = c(TRUE, TRUE)),
@@ -91,6 +97,7 @@ test_that("resolve_names rejects a non-scalar-logical", {
 ### corrupt_pbp_check -- ported from sdv-py's CFBPlayProcess.corrupt_pbp_check.
 
 test_that("an empty play feed is always rejected", {
+  testthat::skip_on_cran()
   # Zero plays is malformed at any point in a game, so this rule does not wait
   # for the completed flag.
   empty <- data.frame(type_text = character(0), stringsAsFactors = FALSE)
@@ -101,6 +108,7 @@ test_that("an empty play feed is always rejected", {
 })
 
 test_that("the count rules only apply to a completed game", {
+  testthat::skip_on_cran()
   short <- data.frame(x = seq_len(12))
   long  <- data.frame(x = seq_len(600))
   ok    <- data.frame(x = seq_len(160))
@@ -115,6 +123,7 @@ test_that("the count rules only apply to a completed game", {
 })
 
 test_that("the boundaries are exactly 50 and 500", {
+  testthat::skip_on_cran()
   # A truncated game models cleanly and looks reasonable, so the thresholds are
   # the only thing standing between a broken feed and a published one.
   expect_true(.pbp_corrupt_check(data.frame(x = seq_len(49)), completed = TRUE))

--- a/tests/testthat/test-pbp_taxonomy.R
+++ b/tests/testthat/test-pbp_taxonomy.R
@@ -1,4 +1,5 @@
 test_that(".pbp_play_types() returns the canonical play-type vectors", {
+  testthat::skip_on_cran()
   tt <- cfbfastR:::.pbp_play_types()
 
   expect_type(tt, "list")

--- a/tests/testthat/test-yahoo_cfb.R
+++ b/tests/testthat/test-yahoo_cfb.R
@@ -1,4 +1,5 @@
 test_that("yahoo_cfb_scoreboard flattens games map and is self-describing", {
+  testthat::skip_on_cran()
   fake <- list(service = list(scoreboard = list(games = list(
     `ncaaf.g.1` = list(gameid = "ncaaf.g.1", home_team_id = "ncaaf.t.1",
                        away_team_id = "ncaaf.t.2", total_home_points = "21",
@@ -11,6 +12,7 @@ test_that("yahoo_cfb_scoreboard flattens games map and is self-describing", {
 })
 
 test_that("legacy wrappers validate category and flatten leaders", {
+  testthat::skip_on_cran()
   fake <- list(data = list(leagues = list(list(leaders = list(
     list(player = list(playerId = "ncaaf.p.9", displayName = "RB Nine",
                        team = list(displayName = "Team C", abbreviation = "TC")),
@@ -27,6 +29,7 @@ test_that("legacy wrappers validate category and flatten leaders", {
 })
 
 test_that("yahoo_cfb_player_season_stats flattens modern payload + is self-describing", {
+  testthat::skip_on_cran()
   fake <- list(data = list(leagues = list(list(footballStats = list(
     list(player = list(playerId = "ncaaf.p.1", displayName = "QB One",
                        team = list(displayName = "Team A", abbreviation = "TA")),
@@ -39,6 +42,7 @@ test_that("yahoo_cfb_player_season_stats flattens modern payload + is self-descr
 })
 
 test_that(".yahoo_modern_rows pivots stats wide with entity columns", {
+  testthat::skip_on_cran()
   payload <- list(data = list(leagues = list(list(footballStats = list(
     list(
       player = list(playerId = "ncaaf.p.1", displayName = "QB One",
@@ -57,6 +61,7 @@ test_that(".yahoo_modern_rows pivots stats wide with entity columns", {
 })
 
 test_that("yahoo_cfb_team_season_stats flattens modern team payload + is self-describing", {
+  testthat::skip_on_cran()
   fake <- list(data = list(leagues = list(list(footballStats = list(
     list(team = list(displayName = "Team A", abbreviation = "TA"),
          stats = list(list(statId = "PASSING_YARDS", value = "4000"))))))))
@@ -70,6 +75,7 @@ test_that("yahoo_cfb_team_season_stats flattens modern team payload + is self-de
 })
 
 test_that("yahoo_cfb_team_season_stats_legacy validates category and flattens team leaders", {
+  testthat::skip_on_cran()
   fake <- list(data = list(leagues = list(list(leaders = list(
     list(team = list(displayName = "Team B", abbreviation = "TB"),
          stats = list(list(statId = "RUSHING_YARDS", value = "2000"))))))))
@@ -88,6 +94,7 @@ test_that("yahoo_cfb_team_season_stats_legacy validates category and flattens te
 })
 
 test_that(".yahoo_entity_cols returns empty list for NULL entity", {
+  testthat::skip_on_cran()
   row_no_player_no_team <- list()
   result <- cfbfastR:::.yahoo_entity_cols(row_no_player_no_team)
   expect_equal(result, list())


### PR DESCRIPTION
Fixes the [Debian incoming pretest ERROR](https://win-builder.r-project.org/incoming_pretest/cfbfastR_3.0.0_20260824_152253/Debian/00check.log): a zstd parquet fixture read in a fourth `test_that` block of `test-parity_air_yards.R` that the previous skip pass missed (CRAN's arrow lacks zstd).

Per policy decision, the **entire suite** now skips on CRAN — every `test_that` block leads with `testthat::skip_on_cran()` (80 blocks patched across 15 files; sweep-verified zero blocks without it). The tests validate parity against committed fixtures and live APIs, which GH Actions runs on every push.

Verified: CRAN conditions → FAIL 0 / PASS 0 / SKIP 310 (3.9s); `NOT_CRAN=true` → tests execute normally. cran-comments carries the resubmission note.

## Summary by Sourcery

Skip the complete test suite on CRAN to avoid environment-dependent failures while preserving validation in continuous integration.

Bug Fixes:
- Prevent CRAN and Debian incoming pretests from failing when the test suite requires unavailable parquet compression support or external resources.

Enhancements:
- Make every testthat block skip on CRAN while retaining normal test execution outside CRAN.

Documentation:
- Add a CRAN resubmission note explaining why the test suite is skipped on CRAN and where it is validated instead.

Tests:
- Apply consistent CRAN skips across the full test suite and verify that CRAN runs execute zero tests while non-CRAN runs remain active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated selected validation, parity, schema, API, and data-processing tests to skip when run on CRAN.
  * Preserved existing test assertions and behavior outside CRAN.
  * Added CRAN-specific handling for tests relying on unsupported compressed fixtures or environment-sensitive checks.

* **Documentation**
  * Added a resubmission note documenting the prior Debian pretest issue and resulting CRAN test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->