### PR TITLE
feat(pbp): score EP, WP, FG + new CP/CPOE from the shared cfb_model_artifacts bundle (fixes #5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Suggests:
     testthat,
     usethis (>= 1.6.0),
     withr,
-    xgboost (>= 1.1)
+    xgboost (>= 1.7)
 Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@ agree on EPA for a given play and a retrain updates both from one publish
   line (the ESPN path, and CFBD before 2013). Sign convention verified over 83
   games: CFBD's `spread` is negative when the home team is favoured, and the
   model reads positive `spread_time` as the team in possession being favoured.
+  `vegas_wpa` and `vegas_wp_after` are derived alongside it, using the same
+  turnover and half/period-end overlays as the naive `wpa`.
 * **New: expected pass rate.** `xpass` and `pass_oe` columns are added on
   scrimmage plays (nflfastR's `xpass` / `pass_oe`), `pass_oe` on the
   percentage-point scale `100 * (pass - xpass)`. Note this model uses an

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,18 @@ agree on EPA for a given play and a retrain updates both from one publish
 * `xgboost` (Suggests) is now required to score EP and its floor moved to
   `>= 1.7` for `.ubj` support. Without it — or offline with no cached copy —
   the retired `nnet` model is loaded as a fallback and still works.
+* The **Win Probability** model moved to the bundle's `wp_naive.ubj` on the
+  same terms. Eleven of its twelve features already existed on the frame; only
+  `is_home` is derived.
+* The **Field Goal** model moved to the bundle's era-aware `fg_model.ubj`
+  (`yards_to_goal` + one-hot `era0..era3`). `season` is now threaded through
+  `.run_epa_wpa()` and the exported `create_epa()` / `epa_fg_probs()` gain a
+  `season` argument (defaulting to `NULL`). Scoring the era-aware model
+  without a season is an error rather than a silent all-zero one-hot.
+* **New: completion probability.** `cp` and `cpoe` columns are added on pass
+  plays, `cpoe` on the percentage-point scale `100 * (completion - cp)`,
+  matching `sportsdataverse-py`. The model loads lazily on first use and the
+  stage degrades to `NA` columns rather than failing.
 * Existing EPA/WPA values **will change**: this is a different model
   generation. Rebuild rather than mixing old and new outputs in one dataset.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,32 @@
+# **cfbfastR (development version)**
+
+### Expected Points model now comes from the shared `cfb_model_artifacts` bundle
+
+The EP model is now the XGBoost artifact published in
+[`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+— **the same artifact `sportsdataverse-py` scores with**, so both libraries
+agree on EPA for a given play and a retrain updates both from one publish
+([#138](https://github.com/sportsdataverse/cfbfastR/issues/138)).
+
+* **Fixes [#5](https://github.com/sportsdataverse/cfbfastR/issues/5)** — `epa_wpa = TRUE`
+  no longer aborts with `predict.nnet(): missing values in 'x'` on mid-era CFBD
+  data (seasons ~2006–2013), in either engine.
+* EP scoring is consolidated behind one internal helper, so the seven
+  next-score probability columns keep their historical names and order and no
+  downstream code changed. **The bundle's class order differs from the retired
+  model's** with no fixed point between them; the permutation is read from the
+  bundle's `MANIFEST.json` and asserted in tests, because getting it wrong
+  yields EP that is wrong yet plausible-looking.
+* Model artifacts are cached under the package cache dir and refreshed on the
+  `cfbfastR.cache_duration` TTL (default 24h), so a republished model is picked
+  up without a package update. An expired cached copy is still used if the
+  release is unreachable.
+* `xgboost` (Suggests) is now required to score EP and its floor moved to
+  `>= 1.7` for `.ubj` support. Without it — or offline with no cached copy —
+  the retired `nnet` model is loaded as a fallback and still works.
+* Existing EPA/WPA values **will change**: this is a different model
+  generation. Rebuild rather than mixing old and new outputs in one dataset.
+
 # **cfbfastR v3.0.0**
 
 ### New release-dataset loaders (39 functions)

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,11 @@ agree on EPA for a given play and a retrain updates both from one publish
   line (the ESPN path, and CFBD before 2013). Sign convention verified over 83
   games: CFBD's `spread` is negative when the home team is favoured, and the
   model reads positive `spread_time` as the team in possession being favoured.
+* **New: expected pass rate.** `xpass` and `pass_oe` columns are added on
+  scrimmage plays (nflfastR's `xpass` / `pass_oe`), `pass_oe` on the
+  percentage-point scale `100 * (pass - xpass)`. Note this model uses an
+  *ordinal* rule-era feature cutting at 2006/2013/**2017**, which is a
+  different encoding from the FG model's one-hot `era0..era3` (2006/2013/2020).
 * Existing EPA/WPA values **will change**: this is a different model
   generation. Rebuild rather than mixing old and new outputs in one dataset.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,12 @@ agree on EPA for a given play and a retrain updates both from one publish
   plays, `cpoe` on the percentage-point scale `100 * (completion - cp)`,
   matching `sportsdataverse-py`. The model loads lazily on first use and the
   stage degrades to `NA` columns rather than failing.
+* **New: spread-aware win probability.** A `vegas_wp` column is added
+  alongside the unchanged naive `wp_before` — the same split nflfastR draws
+  between `wp` and `vegas_wp`. It is `NA` wherever the game has no pre-game
+  line (the ESPN path, and CFBD before 2013). Sign convention verified over 83
+  games: CFBD's `spread` is negative when the home team is favoured, and the
+  model reads positive `spread_time` as the team in possession being favoured.
 * Existing EPA/WPA values **will change**: this is a different model
   generation. Rebuild rather than mixing old and new outputs in one dataset.
 

--- a/R/cfbd_pbp_data.R
+++ b/R/cfbd_pbp_data.R
@@ -670,7 +670,8 @@ cfbd_pbp_data <- function(year,
           add_yardage() |>
           add_player_cols() |>
           prep_epa_df_after() |>
-          create_epa(ep_model = ep_model, fg_model = fg_model) |>
+          create_epa(ep_model = ep_model, fg_model = fg_model,
+                     season = year) |>
           # create_wpa_betting() |>
           create_wpa_naive(wp_model = wp_model)
         p(sprintf("x=%s", as.integer(x)))

--- a/R/cfbd_pbp_data_v2.R
+++ b/R/cfbd_pbp_data_v2.R
@@ -284,7 +284,9 @@ cfbd_pbp_data_v2 <- function(year,
       fg_model   = fg_model,
       wp_model   = wp_model,
       clean_text = TRUE,
-      min_plays  = 20L
+      min_plays  = 20L,
+      # The era-aware FG model needs the season.
+      season     = year
     ) |>
       .pbp_apply_output_schema(output = output)
   }

--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -503,7 +503,8 @@ epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod,
     end_game_ind <- which(dat$TimeSecsRem <= 0)
     current_probs[end_game_ind, ] <- 0
 
-    make_fg_prob <- .fg_make_prob(fg_mod, fg_dat, season = season)
+    # (the FG make-probability is computed once, below, just before it is
+    # used -- a second call here would score the model twice per FG/XP play)
 
     missed_fg_dat <- fg_dat |>
       # Subtract 5.065401 from TimeSecs since average time for FG att:

--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -94,9 +94,9 @@ create_epa <- function(play_df,
     dplyr::rename("yards_to_goal" = "yardline")
 
   # ep_start - make predictions on pred_df
-  ep_start <- as.data.frame(predict(ep_model, pred_df, type = "prob"))
-  # ep_start - rename next score type probability columns to ep_model$lev
-  colnames(ep_start) <- ep_model$lev
+  # .ep_predict() returns the seven next-score probabilities already named AND
+  # ordered by .EP_LEV whichever model generation is loaded.
+  ep_start <- .ep_predict(ep_model, pred_df)
 
   ## 2) epa_fg_probs FG model and missed FG weighted adjustment ----
   # ep_start_update - return FG model predictions and missed FG weighted adjustment
@@ -116,9 +116,7 @@ create_epa <- function(play_df,
   })
   ## 3) pred_df_after prediction ----
   # ep_after - calculate post-play expected points
-  ep_end <- predict(ep_model, pred_df_after, type = "prob")
-  # ep_end - rename next score type probability columns to ep_model$lev
-  colnames(ep_end) <- ep_model$lev
+  ep_end <- .ep_predict(ep_model, pred_df_after)
   # append `_after` to next score type probability columns
   colnames(ep_end) <- paste0(colnames(ep_end), "_after")
   pred_df_after <- cbind(pred_df_after, ep_end)
@@ -227,7 +225,7 @@ create_epa <- function(play_df,
     new_kick["distance"] <- 10
     new_kick["yards_to_goal"] <- 75
     new_kick["log_ydstogo"] <- log(10)
-    ep_kickoffs <- as.data.frame(predict(ep_model, new_kick, type = "prob"))
+    ep_kickoffs <- .ep_predict(ep_model, new_kick)
     if (table(kickoff_ind)[2] > 1) {
       pred_df[kickoff_ind, "ep_before"] <- apply(ep_kickoffs, 1, function(row) {
         sum(row * weights)
@@ -507,8 +505,11 @@ epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod) {
         Goal_To_Go = rep(FALSE, n()),
         # Now first down:
         down = rep("1", n()),
-        # 10 yards to go
+        # 10 yards to go. `log_ydstogo` served the retired nnet formula; the
+        # bundled model reads raw `distance`, which otherwise would have kept
+        # the REAL play's distance and quietly contradicted the hypothetical.
         log_ydstogo = rep(log(10), n()),
+        distance = rep(10, n()),
         # Create Under_TwoMinute_Warning indicator
         Under_two = ifelse(.data$TimeSecsRem < 120,
           TRUE, FALSE
@@ -516,16 +517,9 @@ epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod) {
         pos_score_diff_start = -1 * .data$pos_score_diff_start
       ) |> as.data.frame()
 
-    missed_fg_ep_preds <- ep_model |>
-      predict(newdata = missed_fg_dat, type = "probs") |>
-      as.data.frame()
-
-    if (dim(missed_fg_ep_preds)[2] == 1) {
-      missed_fg_ep_preds <- t(missed_fg_ep_preds)
-    }
-
-
-    colnames(missed_fg_ep_preds) <- ep_model$lev
+    # .ep_predict() always returns an n x 7 lev-named frame, so the old
+    # single-row transpose special case is no longer needed.
+    missed_fg_ep_preds <- .ep_predict(ep_model, missed_fg_dat)
     # Find the rows where TimeSecsRem became 0 or negative and
     # make all the probs equal to 0:
     end_game_i <-

--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -7,6 +7,11 @@
 #' @param play_df (*data.frame* required): Clean PBP as input from [cfbd_pbp_data()]
 #' @param ep_model (*model* default `cfbfastR`'s `ep_model`): Expected Points (EP) Model
 #' @param fg_model (*model* default `cfbfastR`'s `fg_model`): Field Goal (FG) Model
+#' @param season (*numeric* optional): Season of the game. Required when the
+#'   loaded FG model is era-aware (the bundled `fg_model.ubj` takes one-hot
+#'   rule-era features); ignored by the retired single-feature GAM. Passing
+#'   `NULL` with an era-aware model is an error rather than a silent
+#'   all-zero era encoding.
 #' @details Code Description
 #' \describe{
 #'   \item{1. `pred_df`:}{Use select before play model variables -> Make predictions.}
@@ -476,6 +481,8 @@ create_epa <- function(play_df,
 #' @param current_probs (__data.frame__ required): Expected Points (EP) model raw probability outputs from initial prediction
 #' @param ep_model (__model__, default `cfbfastR`'s `ep_model`): FG Model to be used for prediction on field goal (FG) attempts in Play-by-Play data.frame
 #' @param fg_mod (__model__, default `cfbfastR`'s `fg_model`): FG Model to be used for prediction on field goal (FG) attempts in Play-by-Play data.frame
+#' @param season (*numeric* optional): Season of the game, required when the
+#'   loaded FG model is era-aware. See [create_epa()].
 #'
 #' @return Updated expected points probabilities with FG make/miss weighted adjustment
 #' @keywords internal

--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -30,7 +30,8 @@
 
 create_epa <- function(play_df,
                        ep_model,
-                       fg_model) {
+                       fg_model,
+                       season = NULL) {
   #----------------- Code Description--------
   ## 1) pred_df: Use select before play model variables -> Make predictions
   ## 2) epa_fg_probs: Update expected points predictions from before variables with FG make/miss probability weighted adjustment
@@ -104,7 +105,8 @@ create_epa <- function(play_df,
     dat = clean_pbp,
     current_probs = ep_start,
     ep_model = ep_model,
-    fg_mod = fg_model
+    fg_mod = fg_model,
+    season = season
   )
   # append `_before` to next score type probability columns
   colnames(ep_start_update)[1:7] <- paste0(colnames(ep_start_update)[1:7], "_before")
@@ -482,7 +484,8 @@ create_epa <- function(play_df,
 #' @importFrom dplyr mutate
 #' @export
 
-epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod) {
+epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod,
+                         season = NULL) {
   fg_ind <- stringr::str_detect((dat$play_type), "Field Goal")
   ep_ind <- stringr::str_detect((dat$play_type), "Extra Point")
   inds <- fg_ind | ep_ind
@@ -493,7 +496,7 @@ epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod) {
     end_game_ind <- which(dat$TimeSecsRem <= 0)
     current_probs[end_game_ind, ] <- 0
 
-    make_fg_prob <- mgcv::predict.bam(fg_mod, newdata = fg_dat, type = "response")
+    make_fg_prob <- .fg_make_prob(fg_mod, fg_dat, season = season)
 
     missed_fg_dat <- fg_dat |>
       # Subtract 5.065401 from TimeSecs since average time for FG att:
@@ -530,10 +533,7 @@ epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod) {
     )
 
     # Get the probability of making the field goal:
-    make_fg_prob <- as.numeric(mgcv::predict.bam(fg_mod,
-      newdata = fg_dat,
-      type = "response"
-    ))
+    make_fg_prob <- .fg_make_prob(fg_mod, fg_dat, season = season)
     # Multiply each value of the missed_fg_ep_preds by the 1 - make_fg_prob
     missed_fg_ep_preds <-
       missed_fg_ep_preds * (1 - make_fg_prob)

--- a/R/create_wpa_naive.R
+++ b/R/create_wpa_naive.R
@@ -115,7 +115,7 @@ create_wpa_naive <- function(df, wp_model) {
 
   df <- df |>
     dplyr::arrange(.data$game_id, .data$new_id)
-  Off_Win_Prob <- as.vector(predict(wp_model, newdata = df, type = "response"))
+  Off_Win_Prob <- .wp_predict(wp_model, df)
   df$wp_before <- Off_Win_Prob
   # Kickoff plays
   # Calculate EP before at kickoff as what happens if it was a touchback
@@ -129,7 +129,7 @@ create_wpa_naive <- function(df, wp_model) {
     new_kick["log_ydstogo"] <- log(10)
     new_kick["ExpScoreDiff"] <- new_kick["pos_score_diff_start"] + new_kick["ep_before"]
     new_kick["ExpScoreDiff_Time_Ratio"] <- new_kick["ExpScoreDiff"] / (new_kick["adj_TimeSecsRem"] + 1)
-    df[kickoff_ind, "wp_before"] <- as.vector(predict(wp_model, new_kick, type = "response"))
+    df[kickoff_ind, "wp_before"] <- .wp_predict(wp_model, new_kick)
   }
   g_ids <- sort(unique(df$game_id))
   df2 <- purrr::map_dfr(

--- a/R/espn_cfb_game.R
+++ b/R/espn_cfb_game.R
@@ -6240,6 +6240,10 @@ espn_cfb_pbp <- function(game_id, epa_wpa = FALSE, engine = NULL, output = "defa
       # pickcenter <- raw_df[['pickcenter']]
 
       if (isTRUE(epa_wpa)) {
+        # Captured before the pipeline: the era-aware FG model needs a scalar
+        # season, and `season` is one of the columns the chain below renames
+        # away. Without it every FG/XP play aborts in .fg_make_prob().
+        .legacy_season <- suppressWarnings(as.numeric(plays_df$season[1]))
         plays_df <- plays_df |>
           dplyr::rename(
             "play_text" = "plays_text",
@@ -6299,7 +6303,8 @@ espn_cfb_pbp <- function(game_id, epa_wpa = FALSE, engine = NULL, output = "defa
           add_yardage() |>
           add_player_cols() |>
           prep_epa_df_after() |>
-          create_epa(ep_model = ep_model, fg_model = fg_model) |>
+          create_epa(ep_model = ep_model, fg_model = fg_model,
+                     season = .legacy_season) |>
           # create_wpa_betting() |>
           create_wpa_naive(wp_model = wp_model) |>
           dplyr::select(-"ppa") #drop placeholder column

--- a/R/espn_cfb_game.R
+++ b/R/espn_cfb_game.R
@@ -6752,9 +6752,11 @@ espn_cfb_pbp_v2 <- function(game_id,
         wp_model     = wp_model,
         roster       = roster_df,
         participants = participants_df,
-        # The era-aware FG model needs the season; meta$season is resolved
-        # from the event's week/season $ref above.
-        season       = meta$season
+        # The era-aware FG model needs the season. meta$season is NA when the
+        # event's week/season $ref could not be resolved, so fall back to
+        # deriving it from the game date -- otherwise FG scoring aborts and the
+        # outer handler hands back a silently unmodeled game.
+        season       = .cfb_season_or_date(meta$season, meta$game_date)
       ) |>
         dplyr::select(-dplyr::any_of("ppa"))   # drop the placeholder
 

--- a/R/espn_cfb_game.R
+++ b/R/espn_cfb_game.R
@@ -6746,7 +6746,10 @@ espn_cfb_pbp_v2 <- function(game_id,
         fg_model     = fg_model,
         wp_model     = wp_model,
         roster       = roster_df,
-        participants = participants_df
+        participants = participants_df,
+        # The era-aware FG model needs the season; meta$season is resolved
+        # from the event's week/season $ref above.
+        season       = meta$season
       ) |>
         dplyr::select(-dplyr::any_of("ppa"))   # drop the placeholder
 

--- a/R/pbp_create_epa.R
+++ b/R/pbp_create_epa.R
@@ -15,7 +15,7 @@
 #' @importFrom dplyr mutate left_join select rename filter group_by arrange ungroup lead lag rename_with all_of starts_with everything
 #' @importFrom stringr str_detect regex
 #' @import tidyr
-.pbp_create_epa <- function(play_df, ep_model, fg_model) {
+.pbp_create_epa <- function(play_df, ep_model, fg_model, season = NULL) {
   #----------------- Code Description--------
   ## 1) pred_df: Use select before play model variables -> Make predictions
   ## 2) .pbp_epa_fg_probs: Update expected points predictions from before variables with FG make/miss probability weighted adjustment
@@ -102,7 +102,8 @@
     dat = clean_pbp,
     current_probs = ep_start,
     ep_model = ep_model,
-    fg_mod = fg_model
+    fg_mod = fg_model,
+    season = season
   )
   # append `_before` to next score type probability columns
   # Fix (b) Site 2: name-based match instead of positional [1:7]
@@ -398,7 +399,8 @@
 #' @importFrom mgcv predict.bam
 #' @importFrom stringr str_detect
 #' @importFrom dplyr mutate
-.pbp_epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod) {
+.pbp_epa_fg_probs <- function(dat, current_probs, ep_model, fg_mod,
+                              season = NULL) {
   fg_ind <- stringr::str_detect((dat$play_type), "Field Goal")
   ep_ind <- stringr::str_detect((dat$play_type), "Extra Point")
   inds <- fg_ind | ep_ind
@@ -447,10 +449,7 @@
     )
 
     # Get the probability of making the field goal:
-    make_fg_prob <- as.numeric(mgcv::predict.bam(fg_mod,
-      newdata = fg_dat,
-      type = "response"
-    ))
+    make_fg_prob <- .fg_make_prob(fg_mod, fg_dat, season = season)
     # Multiply each value of the missed_fg_ep_preds by the 1 - make_fg_prob
     missed_fg_ep_preds <-
       missed_fg_ep_preds * (1 - make_fg_prob)

--- a/R/pbp_create_epa.R
+++ b/R/pbp_create_epa.R
@@ -91,9 +91,10 @@
     dplyr::rename("yards_to_goal" = "yardline")
 
   # ep_start - make predictions on pred_df
-  ep_start <- as.data.frame(predict(ep_model, pred_df, type = "prob"))
-  # ep_start - rename next score type probability columns to ep_model$lev
-  colnames(ep_start) <- ep_model$lev
+  # .ep_predict() returns the seven next-score probabilities already named AND
+  # ordered by .EP_LEV whichever model generation is loaded, so the positional
+  # `weights` vector below keeps its meaning across the artifact swap.
+  ep_start <- .ep_predict(ep_model, pred_df)
 
   ## 2) .pbp_epa_fg_probs FG model and missed FG weighted adjustment ----
   # ep_start_update - return FG model predictions and missed FG weighted adjustment
@@ -105,7 +106,7 @@
   )
   # append `_before` to next score type probability columns
   # Fix (b) Site 2: name-based match instead of positional [1:7]
-  prob_cols <- ep_model$lev
+  prob_cols <- .EP_LEV
   colnames(ep_start_update)[match(prob_cols, colnames(ep_start_update))] <- paste0(prob_cols, "_before")
   pred_df <- cbind(pred_df, ep_start_update)
   pred_df$ep_before <- NA_real_
@@ -115,9 +116,9 @@
   })
   ## 3) pred_df_after prediction ----
   # ep_after - calculate post-play expected points
-  ep_end <- predict(ep_model, pred_df_after, type = "prob")
-  # ep_end - rename next score type probability columns to ep_model$lev
-  colnames(ep_end) <- ep_model$lev
+  # Scored before the `_end` rename below, so pred_df_after still carries the
+  # plain model column names here.
+  ep_end <- .ep_predict(ep_model, pred_df_after)
   # append `_after` to next score type probability columns
   # Fix (b) Site 3: whole-frame, name-based -- left as-is (no positional indexing)
   colnames(ep_end) <- paste0(colnames(ep_end), "_after")
@@ -148,7 +149,7 @@
     new_kick["distance"] <- 10
     new_kick["yards_to_goal"] <- 75
     new_kick["log_ydstogo"] <- log(10)
-    ep_kickoffs <- as.data.frame(predict(ep_model, new_kick, type = "prob"))
+    ep_kickoffs <- .ep_predict(ep_model, new_kick)
     if (table(kickoff_ind)[2] > 1) {
       pred_df[kickoff_ind, "ep_before"] <- apply(ep_kickoffs, 1, function(row) {
         sum(row * weights)
@@ -421,8 +422,11 @@
         Goal_To_Go = rep(FALSE, n()),
         # Now first down:
         down = rep("1", n()),
-        # 10 yards to go
+        # 10 yards to go. `log_ydstogo` served the retired nnet formula; the
+        # bundled model reads raw `distance`, which otherwise would have kept
+        # the REAL play's distance and quietly contradicted the hypothetical.
         log_ydstogo = rep(log(10), n()),
+        distance = rep(10, n()),
         # Create Under_TwoMinute_Warning indicator
         Under_two = ifelse(.data$TimeSecsRem < 120,
           TRUE, FALSE
@@ -430,16 +434,9 @@
         pos_score_diff_start = -1 * .data$pos_score_diff_start
       ) |> as.data.frame()
 
-    missed_fg_ep_preds <- ep_model |>
-      predict(newdata = missed_fg_dat, type = "probs") |>
-      as.data.frame()
-
-    if (dim(missed_fg_ep_preds)[2] == 1) {
-      missed_fg_ep_preds <- t(missed_fg_ep_preds)
-    }
-
-
-    colnames(missed_fg_ep_preds) <- ep_model$lev
+    # .ep_predict() always returns an n x 7 lev-named frame, so the old
+    # single-row transpose special case is no longer needed.
+    missed_fg_ep_preds <- .ep_predict(ep_model, missed_fg_dat)
     # Find the rows where TimeSecsRem became 0 or negative and
     # make all the probs equal to 0:
     end_game_i <-

--- a/R/pbp_create_wpa_naive.R
+++ b/R/pbp_create_wpa_naive.R
@@ -20,8 +20,9 @@
 .pbp_create_wpa_naive <- function(df, wp_model) {
   df <- df |>
     dplyr::arrange(.data$game_id, .data$new_id)
-  Off_Win_Prob <- as.vector(predict(wp_model, newdata = df, type = "response"))
-  df$wp_before <- Off_Win_Prob
+  # .wp_predict() handles either model generation and derives `is_home`, the
+  # one bundle feature the frame does not already carry.
+  df$wp_before <- .wp_predict(wp_model, df)
   # Kickoff plays
   # Calculate EP before at kickoff as what happens if it was a touchback
   # 25 yard line in 2012 and onwards
@@ -34,7 +35,7 @@
     new_kick["log_ydstogo"] <- log(10)
     new_kick["ExpScoreDiff"] <- new_kick["pos_score_diff_start"] + new_kick["ep_before"]
     new_kick["ExpScoreDiff_Time_Ratio"] <- new_kick["ExpScoreDiff"] / (new_kick["adj_TimeSecsRem"] + 1)
-    df[kickoff_ind, "wp_before"] <- as.vector(predict(wp_model, new_kick, type = "response"))
+    df[kickoff_ind, "wp_before"] <- .wp_predict(wp_model, new_kick)
   }
   g_ids <- sort(unique(df$game_id))
   df2 <- purrr::list_rbind(purrr::map(

--- a/R/pbp_create_wpa_naive.R
+++ b/R/pbp_create_wpa_naive.R
@@ -49,6 +49,57 @@
   return(df2)
 }
 
+#' Modular PBP -- WPA overlays for an arbitrary win-probability column
+#'
+#' The differencing is not a plain `lead(wp) - wp`: possession changes flip the
+#' perspective (`1 - lead_wp`), and half/period ends read the lead-2 play
+#' because the intervening row is a timeout or an end-of-period marker. That
+#' logic is identical whichever WP column is being differenced, so it lives
+#' here once and is driven by `wp` -- the naive `wp_before` and the
+#' spread-aware `vegas_wp` both route through it.
+#'
+#' MUST be called on ONE GAME at a time, already ordered: `dplyr::lead()` here
+#' would otherwise reach across the game boundary and difference the last play
+#' of one game against the first play of the next.
+#'
+#' @param df One game's plays, ordered.
+#' @param wp Numeric win-probability vector to difference.
+#' @return Numeric WPA vector, `nrow(df)` long.
+#' @keywords internal
+#' @noRd
+.wpa_overlay <- function(df, wp) {
+  lead_wp <- dplyr::lead(wp, 1)
+  lead_wp2 <- dplyr::lead(wp, 2)
+
+  wpa_base <- lead_wp - wp
+  wpa_base_nxt <- lead_wp2 - wp
+  wpa_base_nxt_ind <- ifelse(df$pos_team == df$lead_pos_team2, 1, 0)
+  # possession changed hands: the next team's win probability is this team's loss
+  wpa_change <- (1 - lead_wp) - wp
+  wpa_change_nxt <- (1 - lead_wp2) - wp
+  wpa_change_ind <- ifelse(df$pos_team != df$lead_pos_team, 1, 0)
+  wpa_change_nxt_ind <- ifelse(df$pos_team != df$lead_pos_team2, 1, 0)
+
+  wpa_half_end <- ifelse(df$end_of_half == 1 & wpa_base_nxt_ind == 1 &
+    df$play_type != "Timeout", wpa_base_nxt,
+  ifelse(df$end_of_half == 1 & wpa_change_nxt_ind == 1 &
+    df$play_type != "Timeout", wpa_change_nxt,
+  ifelse(df$end_of_half == 1 & df$pos_team_receives_2H_kickoff == 0 &
+    df$play_type == "Timeout", wpa_base,
+  ifelse(wpa_change_ind == 1, wpa_change, wpa_base))))
+
+  ifelse(df$end_of_half == 1 & df$play_type != "Timeout",
+    wpa_half_end,
+    ifelse((df$lead_play_type %in% c("End Period", "End of Half")) & df$change_of_pos_team == 0,
+      wpa_base_nxt,
+      ifelse((df$lead_play_type %in% c("End Period", "End of Half")) & df$change_of_pos_team == 1,
+        wpa_change_nxt,
+        ifelse(wpa_change_ind == 1, wpa_change, wpa_base)
+      )
+    )
+  )
+}
+
 #' Modular PBP -- per-game WPA calculations
 #'
 #' Verbatim refactor of `wpa_calcs_naive()` for `.pbp_create_wpa_naive()`.
@@ -132,5 +183,16 @@
       home_wp_after = round(.data$home_wp_after, 7),
       away_wp_after = round(.data$away_wp_after, 7)
     )
+
+  # Spread-aware WPA, derived with the same overlays via .wpa_overlay(). It is
+  # computed HERE rather than in its own pipeline stage so it inherits this
+  # function's per-game split and ordering -- a lead() spanning a game boundary
+  # would difference the last play of one game against the first of the next.
+  # The naive block above is left inline and untouched: it produces published
+  # values, and test-wpa_overlay asserts the helper reproduces it exactly.
+  if ("vegas_wp" %in% names(df2)) {
+    df2$vegas_wpa <- round(.wpa_overlay(df2, df2$vegas_wp), 7)
+    df2$vegas_wp_after <- round(df2$vegas_wp + df2$vegas_wpa, 7)
+  }
   return(df2)
 }

--- a/R/pbp_epa_wpa_engine.R
+++ b/R/pbp_epa_wpa_engine.R
@@ -105,14 +105,16 @@
     .pbp_prep_epa_df_after() |>
     .pbp_create_epa(ep_model = ep_model, fg_model = fg_model,
                     season = season) |>
+    # vegas_wp is scored BEFORE the WPA stage so that stage -- which already
+    # splits per game and orders the plays -- can difference it into vegas_wpa
+    # without a second grouping pass. A lead() across a game boundary would
+    # otherwise difference two different games.
+    .pbp_add_vegas_wp() |>
     .pbp_create_wpa_naive(wp_model = wp_model) |>
     # Additive and self-contained: CP/CPOE lazily loads its own bundled model
     # and emits all-NA columns rather than raising when it or its inputs are
     # unavailable, matching sdv-py `__process_cpoe`.
     .pbp_add_cp_cpoe() |>
-    # Additive too: `vegas_wp` alongside the untouched naive `wp_before`,
-    # NA wherever the game has no pre-game line.
-    .pbp_add_vegas_wp() |>
     # xpass needs the season for its ORDINAL era feature (2017 cut), which is
     # a different encoding from the FG model's one-hot era (2020 cut).
     .pbp_add_xpass(season = season)

--- a/R/pbp_epa_wpa_engine.R
+++ b/R/pbp_epa_wpa_engine.R
@@ -112,7 +112,10 @@
     .pbp_add_cp_cpoe() |>
     # Additive too: `vegas_wp` alongside the untouched naive `wp_before`,
     # NA wherever the game has no pre-game line.
-    .pbp_add_vegas_wp()
+    .pbp_add_vegas_wp() |>
+    # xpass needs the season for its ORDINAL era feature (2017 cut), which is
+    # a different encoding from the FG model's one-hot era (2020 cut).
+    .pbp_add_xpass(season = season)
 }
 
 #' Modular PBP -- per-game wrapper with min-plays skip and progress

--- a/R/pbp_epa_wpa_engine.R
+++ b/R/pbp_epa_wpa_engine.R
@@ -109,7 +109,10 @@
     # Additive and self-contained: CP/CPOE lazily loads its own bundled model
     # and emits all-NA columns rather than raising when it or its inputs are
     # unavailable, matching sdv-py `__process_cpoe`.
-    .pbp_add_cp_cpoe()
+    .pbp_add_cp_cpoe() |>
+    # Additive too: `vegas_wp` alongside the untouched naive `wp_before`,
+    # NA wherever the game has no pre-game line.
+    .pbp_add_vegas_wp()
 }
 
 #' Modular PBP -- per-game wrapper with min-plays skip and progress

--- a/R/pbp_epa_wpa_engine.R
+++ b/R/pbp_epa_wpa_engine.R
@@ -65,7 +65,8 @@
                          wp_model,
                          clean_text = FALSE,
                          roster = NULL,
-                         participants = NULL) {
+                         participants = NULL,
+                         season = NULL) {
   if (isTRUE(clean_text)) {
     df <- clean_play_text(df)
   }
@@ -102,7 +103,8 @@
     # re-request the same two rosters for every game those teams played.
     .pbp_attach_player_ids(roster = roster) |>
     .pbp_prep_epa_df_after() |>
-    .pbp_create_epa(ep_model = ep_model, fg_model = fg_model) |>
+    .pbp_create_epa(ep_model = ep_model, fg_model = fg_model,
+                    season = season) |>
     .pbp_create_wpa_naive(wp_model = wp_model) |>
     # Additive and self-contained: CP/CPOE lazily loads its own bundled model
     # and emits all-NA columns rather than raising when it or its inputs are
@@ -137,7 +139,8 @@
                                  clean_text = FALSE,
                                  min_plays = 20L,
                                  rosters = NULL,
-                                 participants = NULL) {
+                                 participants = NULL,
+                                 season = NULL) {
   # Slice a multi-game side frame down to one game, tolerating a frame that has
   # no game_id (a caller who already scoped it) and a game with no rows.
   warned_no_gid <- FALSE
@@ -183,7 +186,8 @@
       wp_model     = wp_model,
       clean_text   = clean_text,
       roster       = slice_for(rosters, gid),
-      participants = slice_for(participants, gid)
+      participants = slice_for(participants, gid),
+      season       = season
     )
     p(sprintf("game_id=%s", gid))
     modeled

--- a/R/pbp_epa_wpa_engine.R
+++ b/R/pbp_epa_wpa_engine.R
@@ -117,7 +117,10 @@
     .pbp_add_cp_cpoe() |>
     # xpass needs the season for its ORDINAL era feature (2017 cut), which is
     # a different encoding from the FG model's one-hot era (2020 cut).
-    .pbp_add_xpass(season = season)
+    .pbp_add_xpass(season = season) |>
+    # Model-scoring half of the two-point surface; the WP-comparison decision
+    # columns need hypothetical ensuing-drive states and are tracked in #140.
+    .pbp_add_two_pt_prob(season = season)
 }
 
 #' Modular PBP -- per-game wrapper with min-plays skip and progress

--- a/R/pbp_epa_wpa_engine.R
+++ b/R/pbp_epa_wpa_engine.R
@@ -103,7 +103,11 @@
     .pbp_attach_player_ids(roster = roster) |>
     .pbp_prep_epa_df_after() |>
     .pbp_create_epa(ep_model = ep_model, fg_model = fg_model) |>
-    .pbp_create_wpa_naive(wp_model = wp_model)
+    .pbp_create_wpa_naive(wp_model = wp_model) |>
+    # Additive and self-contained: CP/CPOE lazily loads its own bundled model
+    # and emits all-NA columns rather than raising when it or its inputs are
+    # unavailable, matching sdv-py `__process_cpoe`.
+    .pbp_add_cp_cpoe()
 }
 
 #' Modular PBP -- per-game wrapper with min-plays skip and progress

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -32,6 +32,7 @@ NULL
 #' @keywords internal
 #' @noRd
 .cfb_model_env <- new.env(parent = emptyenv())
+.cfb_model_env$unavailable <- list()
 
 #' EP next-score class order, point values and feature contract
 #'
@@ -353,11 +354,18 @@ NULL
 #' @noRd
 .cfb_cp_model <- function() {
   if (!is.null(.cfb_model_env$cp_model)) return(.cfb_model_env$cp_model)
-  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  # A failed fetch is remembered too. Without it .cfb_model_file() retries the
+  # download on EVERY game of a season sweep and pays the timeout each time.
+  if (isTRUE(.cfb_model_env$unavailable[["cp_model"]])) return(NULL)
+  fail <- function() {
+    .cfb_model_env$unavailable[["cp_model"]] <- TRUE
+    NULL
+  }
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(fail())
   f <- .cfb_model_file("cfb_cp_model.ubj")
-  if (is.null(f)) return(NULL)
+  if (is.null(f)) return(fail())
   b <- try(xgboost::xgb.load(f), silent = TRUE)
-  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  if (inherits(b, "try-error") || is.null(b)) return(fail())
   .cfb_model_env$cp_model <- b
   b
 }
@@ -450,6 +458,42 @@ NULL
   df$cp <- ifelse(is_pass, p, NA_real_)
   df$cpoe <- ifelse(is_pass & !is.na(comp), 100 * (comp - df$cp), NA_real_)
   df
+}
+
+#' Season of a game, falling back to its date
+#'
+#' `.espn_pbp_game_meta()` leaves `season` as `NA_integer_` when the event's
+#' week/season `$ref` cannot be resolved. Handing that to the era-aware FG
+#' model aborts scoring for the whole game, and the wrapper's outer handler
+#' swallows it -- the game comes back silently unmodeled.
+#'
+#' The season is therefore DERIVED from the game date rather than defaulted:
+#' fabricating one would produce a valid-looking era one-hot and quietly skew
+#' every field-goal probability, which is the failure this whole path is built
+#' to avoid. The cut matches [most_recent_cfb_season()] -- a game before
+#' August belongs to the previous season, which is what keeps bowl and playoff
+#' games in January with the season they were played in.
+#'
+#' @param season Season as resolved by the caller; used when usable.
+#' @param game_date Date-like string, e.g. ESPN's ISO timestamp.
+#' @return Numeric season, or `NA_real_` when neither source is usable.
+#' @keywords internal
+#' @noRd
+.cfb_season_or_date <- function(season, game_date = NULL) {
+  s <- suppressWarnings(as.numeric(season))
+  if (length(s) && !all(is.na(s))) return(s)
+  if (is.null(game_date) || !length(game_date) || all(is.na(game_date))) {
+    return(NA_real_)
+  }
+  # tryCatch, not suppressWarnings: as.Date() on an unparseable string ERRORS
+  # ("character string is not in a standard unambiguous format"), which would
+  # propagate out of the very helper that exists to degrade gracefully.
+  d <- tryCatch(as.Date(substr(as.character(game_date[1]), 1, 10)),
+                error = function(e) NA)
+  if (length(d) != 1L || is.na(d)) return(NA_real_)
+  yr <- as.numeric(format(d, "%Y"))
+  mo <- as.numeric(format(d, "%m"))
+  ifelse(mo < 8, yr - 1, yr)
 }
 
 #' Field-goal model feature contract and rule-era cuts
@@ -554,11 +598,18 @@ NULL
 #' @noRd
 .cfb_wp_spread_model <- function() {
   if (!is.null(.cfb_model_env$wp_spread)) return(.cfb_model_env$wp_spread)
-  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  # A failed fetch is remembered too. Without it .cfb_model_file() retries the
+  # download on EVERY game of a season sweep and pays the timeout each time.
+  if (isTRUE(.cfb_model_env$unavailable[["wp_spread"]])) return(NULL)
+  fail <- function() {
+    .cfb_model_env$unavailable[["wp_spread"]] <- TRUE
+    NULL
+  }
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(fail())
   f <- .cfb_model_file("wp_spread.ubj")
-  if (is.null(f)) return(NULL)
+  if (is.null(f)) return(fail())
   b <- try(xgboost::xgb.load(f), silent = TRUE)
-  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  if (inherits(b, "try-error") || is.null(b)) return(fail())
   .cfb_model_env$wp_spread <- b
   b
 }
@@ -675,11 +726,18 @@ NULL
 #' @noRd
 .cfb_xpass_model <- function() {
   if (!is.null(.cfb_model_env$xpass)) return(.cfb_model_env$xpass)
-  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  # A failed fetch is remembered too. Without it .cfb_model_file() retries the
+  # download on EVERY game of a season sweep and pays the timeout each time.
+  if (isTRUE(.cfb_model_env$unavailable[["xpass"]])) return(NULL)
+  fail <- function() {
+    .cfb_model_env$unavailable[["xpass"]] <- TRUE
+    NULL
+  }
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(fail())
   f <- .cfb_model_file("xpass_model.ubj")
-  if (is.null(f)) return(NULL)
+  if (is.null(f)) return(fail())
   b <- try(xgboost::xgb.load(f), silent = TRUE)
-  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  if (inherits(b, "try-error") || is.null(b)) return(fail())
   .cfb_model_env$xpass <- b
   b
 }
@@ -747,11 +805,18 @@ NULL
 #' @noRd
 .cfb_two_pt_model <- function() {
   if (!is.null(.cfb_model_env$two_pt)) return(.cfb_model_env$two_pt)
-  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  # A failed fetch is remembered too. Without it .cfb_model_file() retries the
+  # download on EVERY game of a season sweep and pays the timeout each time.
+  if (isTRUE(.cfb_model_env$unavailable[["two_pt"]])) return(NULL)
+  fail <- function() {
+    .cfb_model_env$unavailable[["two_pt"]] <- TRUE
+    NULL
+  }
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(fail())
   f <- .cfb_model_file("two_pt_model.ubj")
-  if (is.null(f)) return(NULL)
+  if (is.null(f)) return(fail())
   b <- try(xgboost::xgb.load(f), silent = TRUE)
-  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  if (inherits(b, "try-error") || is.null(b)) return(fail())
   .cfb_model_env$two_pt <- b
   b
 }

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -17,11 +17,10 @@
 #'   one place is the point -- a per-call-site fix would leave the next new
 #'   call site free to get it wrong.
 #'
-#' @name cfb_model_artifacts
 #' @keywords internal
+#' @noRd
 NULL
 
-#' @rdname cfb_model_artifacts
 #' @keywords internal
 #' @noRd
 .CFB_MODEL_BASE <- paste0(
@@ -46,7 +45,6 @@ NULL
 #' @noRd
 .EP_LEV <- c("No_Score", "FG", "Opp_FG", "Opp_Safety", "Opp_TD", "Safety", "TD")
 
-#' @rdname cfb_model_artifacts
 #' @keywords internal
 #' @noRd
 .EP_FEATURES <- c(
@@ -460,7 +458,6 @@ NULL
 #' @noRd
 .FG_ERA_CUTS <- c(2006, 2013, 2020)
 
-#' @rdname cfb_model_artifacts
 #' @keywords internal
 #' @noRd
 .FG_FEATURES <- c("yards_to_goal", "era0", "era1", "era2", "era3")
@@ -641,7 +638,6 @@ NULL
 #' @noRd
 .XPASS_ERA_CUTS <- c(2006, 2013, 2017)
 
-#' @rdname cfb_model_artifacts
 #' @keywords internal
 #' @noRd
 .XPASS_FEATURES <- c(

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -97,9 +97,14 @@ NULL
   )
   if (!inherits(ok, "try-error") && file.exists(tmp) && file.size(tmp) > 0) {
     # Only replace the cached copy once the download is complete, so an
-    # interrupted fetch can't leave a truncated model in place.
-    file.rename(tmp, dest)
-    return(dest)
+    # interrupted fetch can't leave a truncated model in place. file.rename()
+    # returns FALSE rather than erroring when the destination is locked (a
+    # concurrent R session on Windows holds the file), so returning `dest`
+    # unconditionally would hand back a stale-or-absent path as if it were the
+    # fresh download.
+    if (isTRUE(file.rename(tmp, dest))) return(dest)
+    # Rename lost: score from the freshly downloaded copy in place.
+    return(tmp)
   }
   unlink(tmp)
   # Stale beats absent: an expired cached copy still scores.
@@ -184,6 +189,100 @@ NULL
   )
   colnames(m) <- .EP_FEATURES
   m
+}
+
+#' Win Probability feature contract (naive, spread-free)
+#'
+#' Order matters -- it is the booster's own feature order, taken from the
+#' bundle manifest. Eleven of the twelve already exist on the frame
+#' `.pbp_create_wpa_naive()` receives; only `is_home` is derived here.
+#'
+#' @keywords internal
+#' @noRd
+.WP_NAIVE_FEATURES <- c(
+  "pos_team_receives_2H_kickoff", "TimeSecsRem", "adj_TimeSecsRem",
+  "ExpScoreDiff_Time_Ratio", "pos_score_diff_start", "down", "distance",
+  "yards_to_goal", "is_home", "pos_team_timeouts_rem_before",
+  "def_pos_team_timeouts_rem_before", "period"
+)
+
+#' Is the team in possession the home team?
+#'
+#' Mirrors sdv-py's `is_home = pos_team == homeTeamId` (it compares team ids;
+#' the cfbfastR frame carries team names, same semantic). Returns 0/1 with
+#' `NA` treated as not-home, since the booster cannot take a missing value and
+#' a neutral-site or unresolved possession team should not fabricate an
+#' advantage.
+#'
+#' @keywords internal
+#' @noRd
+.wp_is_home <- function(newdata) {
+  if ("is_home" %in% names(newdata)) {
+    v <- suppressWarnings(as.numeric(newdata$is_home))
+    return(ifelse(is.na(v), 0, v))
+  }
+  if (!all(c("pos_team", "home") %in% names(newdata))) {
+    cli::cli_abort(c(
+      "Cannot derive {.field is_home} for the WP model.",
+      i = "Need either {.field is_home}, or both {.field pos_team} and {.field home}."
+    ))
+  }
+  as.numeric(!is.na(newdata$pos_team) & !is.na(newdata$home) &
+               newdata$pos_team == newdata$home)
+}
+
+#' Build the WP model's feature matrix
+#'
+#' @param newdata One row per play, carrying the WP inputs
+#'   `.pbp_create_epa()` prepares.
+#' @keywords internal
+#' @noRd
+.wp_feature_matrix <- function(newdata) {
+  derived <- "is_home"
+  need <- setdiff(.WP_NAIVE_FEATURES, derived)
+  missing_cols <- setdiff(need, names(newdata))
+  if (length(missing_cols)) {
+    # Bound locally: cli's glue transformer cannot interpolate a dot-prefixed
+    # symbol inside {.field {...}}.
+    wanted <- .WP_NAIVE_FEATURES
+    cli::cli_abort(c(
+      "WP scoring frame is missing required column{?s}: {.field {missing_cols}}.",
+      i = "The bundled WP model needs {.field {wanted}}."
+    ))
+  }
+  cols <- lapply(need, function(nm) {
+    # as.character() first so a factor `down` contributes its VALUE, not its
+    # level code -- the same trap guarded in .ep_feature_matrix().
+    suppressWarnings(as.numeric(as.character(newdata[[nm]])))
+  })
+  names(cols) <- need
+  cols$is_home <- .wp_is_home(newdata)
+  m <- do.call(cbind, cols[.WP_NAIVE_FEATURES])
+  colnames(m) <- .WP_NAIVE_FEATURES
+  m
+}
+
+#' Score the Win Probability model, whichever generation is loaded
+#'
+#' @param wp_model The bundle's `xgb.Booster`, or the retired `mgcv::bam` GAM.
+#' @param newdata One row per play.
+#' @return Numeric vector of offense win probabilities, `nrow(newdata)` long.
+#' @keywords internal
+#' @noRd
+.wp_predict <- function(wp_model, newdata) {
+  if (!inherits(wp_model, "xgb.Booster")) {
+    return(as.vector(stats::predict(wp_model, newdata = newdata,
+                                    type = "response")))
+  }
+  rlang::check_installed("xgboost", reason = "to score the bundled WP model.")
+  x <- .wp_feature_matrix(newdata)
+  p <- as.numeric(stats::predict(wp_model, x))
+  if (length(p) != nrow(x)) {
+    cli::cli_abort(
+      "WP model returned {length(p)} value{?s} for {nrow(x)} play{?s}."
+    )
+  }
+  p
 }
 
 #' Score the EP model, whichever generation is loaded

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -327,3 +327,118 @@ NULL
   colnames(p) <- .EP_LEV
   as.data.frame(p)
 }
+
+#' Completion Probability feature contract
+#'
+#' Order is the booster's own, from the bundle manifest.
+#'
+#' **`score_diff` is fed from `pos_score_diff_start`, not from the frame's own
+#' `score_diff` column.** Both exist in cfbfastR and they are NOT equal (the
+#' former is signed from the possessing team's view), so reading the
+#' like-named column would produce completion probabilities that are wrong yet
+#' entirely plausible. sdv-py's `cp_sources` map is the reference.
+#'
+#' @keywords internal
+#' @noRd
+.CP_FEATURES <- c(
+  "down", "distance", "yards_to_goal", "score_diff",
+  "seconds_remaining", "is_home", "period", "passing_down"
+)
+
+#' Lazily load the bundled completion-probability model
+#'
+#' Unlike EP/WP there is no legacy CFB CP model to fall back to, so this is
+#' bundle-or-nothing and returns `NULL` when unavailable. Loaded on first use
+#' rather than at `.onLoad()` so users who never ask for CP pay no download.
+#'
+#' @keywords internal
+#' @noRd
+.cfb_cp_model <- function() {
+  if (!is.null(.cfb_model_env$cp_model)) return(.cfb_model_env$cp_model)
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  f <- .cfb_model_file("cfb_cp_model.ubj")
+  if (is.null(f)) return(NULL)
+  b <- try(xgboost::xgb.load(f), silent = TRUE)
+  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  .cfb_model_env$cp_model <- b
+  b
+}
+
+#' Is this a passing down?
+#'
+#' cfbfastR/sdv-py definition: a scrimmage play on 2nd & 8+, 3rd & 5+, or
+#' 4th & 5+. cfbfastR carries no `scrimmage_play` column, so it is taken as
+#' pass-or-rush.
+#'
+#' @keywords internal
+#' @noRd
+.cp_passing_down <- function(df) {
+  num <- function(nm) if (nm %in% names(df)) {
+    suppressWarnings(as.numeric(as.character(df[[nm]])))
+  } else rep(NA_real_, nrow(df))
+  scrimmage <- (num("pass") %in% 1) | (num("rush") %in% 1)
+  # `%in%` above collapses NA to FALSE, which is the intent: an unclassified
+  # play is not a passing down.
+  d <- num("down"); dist <- num("distance")
+  out <- scrimmage & (
+    (d == 2 & dist >= 8) | (d == 3 & dist >= 5) | (d == 4 & dist >= 5)
+  )
+  as.numeric(!is.na(out) & out)
+}
+
+#' Build the CP model's feature matrix
+#' @keywords internal
+#' @noRd
+.cp_feature_matrix <- function(df) {
+  n <- nrow(df)
+  pick <- function(nm) suppressWarnings(as.numeric(as.character(df[[nm]])))
+  m <- cbind(
+    down = pick("down"),
+    distance = pick("distance"),
+    yards_to_goal = pick("yards_to_goal"),
+    # NOT df$score_diff -- see .CP_FEATURES.
+    score_diff = pick("pos_score_diff_start"),
+    seconds_remaining = pick("TimeSecsRem"),
+    is_home = .wp_is_home(df),
+    period = pick("period"),
+    passing_down = .cp_passing_down(df)
+  )
+  colnames(m) <- .CP_FEATURES
+  m
+}
+
+#' Append completion probability (`cp`) and completion % over expected (`cpoe`)
+#'
+#' `cp` is populated on pass plays only; `cpoe` is
+#' `100 * (completion - cp)` on those same plays, matching sdv-py's
+#' percentage-point scale. Both are `NA` elsewhere.
+#'
+#' Never raises: a missing model, missing `xgboost`, or a frame lacking the
+#' required inputs yields all-`NA` columns, so the surface is safe to run
+#' unconditionally in the pipeline.
+#'
+#' @keywords internal
+#' @noRd
+.pbp_add_cp_cpoe <- function(df) {
+  # rep() not a scalar: `df$cp <- NA_real_` errors on a zero-row frame
+  # ("replacement has 1 row, data has 0").
+  df$cp <- rep(NA_real_, nrow(df))
+  df$cpoe <- rep(NA_real_, nrow(df))
+  need <- c("down", "distance", "yards_to_goal", "pos_score_diff_start",
+            "TimeSecsRem", "period", "pass", "completion")
+  if (!nrow(df) || !all(need %in% names(df))) return(df)
+  model <- .cfb_cp_model()
+  if (is.null(model)) return(df)
+
+  p <- try({
+    x <- .cp_feature_matrix(df)
+    as.numeric(stats::predict(model, x))
+  }, silent = TRUE)
+  if (inherits(p, "try-error") || length(p) != nrow(df)) return(df)
+
+  is_pass <- suppressWarnings(as.numeric(as.character(df$pass))) %in% 1
+  comp <- suppressWarnings(as.numeric(as.character(df$completion)))
+  df$cp <- ifelse(is_pass, p, NA_real_)
+  df$cpoe <- ifelse(is_pass & !is.na(comp), 100 * (comp - df$cp), NA_real_)
+  df
+}

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -532,3 +532,99 @@ NULL
   keep <- intersect(fnames, colnames(x))
   as.numeric(stats::predict(fg_mod, x[, keep, drop = FALSE]))
 }
+
+#' Spread-aware Win Probability feature contract
+#'
+#' `wp_naive` plus `spread_time` in slot 2 -- the booster's own order.
+#'
+#' @keywords internal
+#' @noRd
+.WP_SPREAD_FEATURES <- append(.WP_NAIVE_FEATURES, "spread_time", after = 1L)
+
+#' Lazily load the bundled spread-aware WP model
+#' @keywords internal
+#' @noRd
+.cfb_wp_spread_model <- function() {
+  if (!is.null(.cfb_model_env$wp_spread)) return(.cfb_model_env$wp_spread)
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  f <- .cfb_model_file("wp_spread.ubj")
+  if (is.null(f)) return(NULL)
+  b <- try(xgboost::xgb.load(f), silent = TRUE)
+  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  .cfb_model_env$wp_spread <- b
+  b
+}
+
+#' Spread from the possessing team's point of view
+#'
+#' **Sign convention, verified empirically over 83 games of 2021 week 1 with
+#' zero exceptions** (`formatted_spread` names the favourite, so it is ground
+#' truth): CFBD's `spread` is negative when the HOME team is favoured and
+#' positive when the AWAY team is favoured.
+#'
+#' The booster reads the opposite orientation: scoring the model directly shows
+#' win probability rising monotonically with `spread_time`
+#' (-28 -> 0.04, 0 -> 0.49, +28 -> 0.96), i.e. **positive means the team in
+#' possession is favoured**. So the home team's spread is negated and the away
+#' team's is kept.
+#'
+#' Getting this backwards is not a crash -- it produces confident, exactly
+#' inverted win probabilities. That is why the convention is pinned by test.
+#'
+#' @keywords internal
+#' @noRd
+.wp_pos_team_spread <- function(df) {
+  if (!all(c("spread", "pos_team", "home") %in% names(df))) return(NULL)
+  spread <- suppressWarnings(as.numeric(df$spread))
+  if (all(is.na(spread))) return(NULL)
+  is_home <- !is.na(df$pos_team) & !is.na(df$home) & df$pos_team == df$home
+  ifelse(is_home, -spread, spread)
+}
+
+#' Time-decayed spread (`spread_time`)
+#'
+#' `pos_team_spread * exp(-4 * elapsed_share)`, so the pre-game line's
+#' influence decays as the game runs down. `elapsed_share` is clamped at 0
+#' below only, matching sdv-py -- its nominal upper clamp cannot bind for any
+#' non-negative `adj_TimeSecsRem`.
+#'
+#' @keywords internal
+#' @noRd
+.wp_spread_time <- function(df) {
+  pts <- .wp_pos_team_spread(df)
+  if (is.null(pts)) return(NULL)
+  adj <- suppressWarnings(as.numeric(df$adj_TimeSecsRem))
+  elapsed_share <- pmax((3600 - adj) / 3600, 0)
+  pts * exp(-4 * elapsed_share)
+}
+
+#' Append spread-aware win probability (`vegas_wp`)
+#'
+#' Additive and non-breaking: the naive `wp_before` / `wpa` columns are left
+#' exactly as they were, and `vegas_wp` is added alongside -- the same split
+#' nflfastR draws between `wp` and `vegas_wp`. `NA` wherever no pre-game spread
+#' is available (the whole ESPN path today, and CFBD before 2013).
+#'
+#' Never raises; a missing model or missing inputs yields an all-`NA` column.
+#'
+#' @keywords internal
+#' @noRd
+.pbp_add_vegas_wp <- function(df) {
+  df$vegas_wp <- rep(NA_real_, nrow(df))
+  if (!nrow(df)) return(df)
+  spread_time <- .wp_spread_time(df)
+  if (is.null(spread_time)) return(df)
+  model <- .cfb_wp_spread_model()
+  if (is.null(model)) return(df)
+
+  p <- try({
+    base <- .wp_feature_matrix(df)
+    x <- cbind(base, spread_time = spread_time)[, .WP_SPREAD_FEATURES, drop = FALSE]
+    as.numeric(stats::predict(model, x))
+  }, silent = TRUE)
+  if (inherits(p, "try-error") || length(p) != nrow(df)) return(df)
+
+  # Rows whose game had no line keep NA rather than a spread-less guess.
+  df$vegas_wp <- ifelse(is.na(spread_time), NA_real_, p)
+  df
+}

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -732,3 +732,135 @@ NULL
   df$pass_oe <- ifelse(scrimmage & !is.na(pass), 100 * (pass - df$xpass), NA_real_)
   df
 }
+
+#' Two-point conversion feature contract
+#'
+#' Uses the ORDINAL era ([.cfb_era_ordinal()], cuts 2006/2013/2017), the same
+#' encoding `xpass_model` takes -- not the one-hot set the FG model uses.
+#'
+#' @keywords internal
+#' @noRd
+.TWO_PT_FEATURES <- c("posteam_spread", "posteam_total", "pos_score_diff", "era")
+
+#' Lazily load the bundled two-point conversion model
+#' @keywords internal
+#' @noRd
+.cfb_two_pt_model <- function() {
+  if (!is.null(.cfb_model_env$two_pt)) return(.cfb_model_env$two_pt)
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  f <- .cfb_model_file("two_pt_model.ubj")
+  if (is.null(f)) return(NULL)
+  b <- try(xgboost::xgb.load(f), silent = TRUE)
+  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  .cfb_model_env$two_pt <- b
+  b
+}
+
+#' Implied team total for the team in possession
+#'
+#' Not the game over/under: the market's expected points for THIS team, split
+#' out of the total using the spread. `(homeTeamSpread + overUnder) / 2` when
+#' the posteam is home, `(overUnder - homeTeamSpread) / 2` when away.
+#'
+#' `homeTeamSpread` is the negation of CFBD's `spread` -- CFBD is negative when
+#' the home team is favoured (verified over 83 games, see
+#' [.wp_pos_team_spread()]) while `homeTeamSpread` is positive then. Skipping
+#' that conversion silently swaps the two teams' implied totals.
+#'
+#' @keywords internal
+#' @noRd
+.cfb_posteam_total <- function(df) {
+  if (!all(c("spread", "over_under") %in% names(df))) return(NULL)
+  spread <- suppressWarnings(as.numeric(df$spread))
+  ou <- suppressWarnings(as.numeric(df$over_under))
+  if (all(is.na(spread)) || all(is.na(ou))) return(NULL)
+  home_spread <- -spread
+  is_home <- .wp_is_home(df) == 1
+  ifelse(is_home, (home_spread + ou) / 2, (ou - home_spread) / 2)
+}
+
+#' Score differential at the two-point decision, from the scoring team's view
+#'
+#' The PAT shares the touchdown's play row in this data (CFBD emits no separate
+#' extra-point rows), so `pos_score_diff_start` is the PRE-touchdown margin and
+#' the decision has to be scored at the POST-touchdown one: add 6.
+#'
+#' The `+6` applies to OFFENSIVE touchdowns only. `pass_td` also fires on
+#' pick-sixes, so it is ANDed with `offense_score_play`; without that a
+#' defensive return touchdown would push the possessing team's score frame the
+#' wrong way by six points.
+#'
+#' @keywords internal
+#' @noRd
+.two_pt_score_diff <- function(df) {
+  diff <- suppressWarnings(as.numeric(df$pos_score_diff_start))
+  tf <- function(nm) {
+    if (!nm %in% names(df)) return(rep(FALSE, nrow(df)))
+    v <- df[[nm]]
+    if (is.logical(v)) return(!is.na(v) & v)
+    suppressWarnings(as.numeric(v)) %in% 1
+  }
+  offensive_td <- (tf("pass_td") | tf("rush_td")) & tf("offense_score_play")
+  ifelse(offensive_td, diff + 6, diff)
+}
+
+#' Rows where a two-point decision is actually faced
+#'
+#' Offensive touchdowns. A defensive score is not the possessing team's
+#' decision, and a non-scoring play has no try to make.
+#'
+#' @keywords internal
+#' @noRd
+.two_pt_decision_rows <- function(df) {
+  tf <- function(nm) {
+    if (!nm %in% names(df)) return(rep(FALSE, nrow(df)))
+    v <- df[[nm]]
+    if (is.logical(v)) return(!is.na(v) & v)
+    suppressWarnings(as.numeric(v)) %in% 1
+  }
+  (tf("pass_td") | tf("rush_td")) & tf("offense_score_play")
+}
+
+#' Append the two-point conversion probability (`prob_2pt`)
+#'
+#' The bundled model's conversion probability on the rows where a team has just
+#' scored an offensive touchdown and must choose between the extra point and
+#' going for two. `NA` on every other row, and wherever the game has no
+#' pre-game line (the model reads the spread and the implied team total).
+#'
+#' This is the model-scoring half of the surface. The full cfb4th decision
+#' (`two_pt_wp` / `xp_wp` / `two_pt_recommendation`) additionally needs the
+#' opponent's ensuing-drive win probability scored for each try outcome, which
+#' is tracked separately.
+#'
+#' Never raises.
+#'
+#' @param season Season of the game, for the ordinal era feature.
+#' @keywords internal
+#' @noRd
+.pbp_add_two_pt_prob <- function(df, season = NULL) {
+  df$prob_2pt <- rep(NA_real_, nrow(df))
+  if (!nrow(df) || !"pos_score_diff_start" %in% names(df)) return(df)
+  if (is.null(season) || all(is.na(season))) return(df)
+  total <- .cfb_posteam_total(df)
+  spread <- .wp_pos_team_spread(df)
+  if (is.null(total) || is.null(spread)) return(df)
+  model <- .cfb_two_pt_model()
+  if (is.null(model)) return(df)
+
+  p <- try({
+    x <- cbind(
+      posteam_spread = spread,
+      posteam_total = total,
+      pos_score_diff = .two_pt_score_diff(df),
+      era = .cfb_era_ordinal(season, nrow(df))
+    )
+    colnames(x) <- .TWO_PT_FEATURES
+    as.numeric(stats::predict(model, x))
+  }, silent = TRUE)
+  if (inherits(p, "try-error") || length(p) != nrow(df)) return(df)
+
+  rows <- .two_pt_decision_rows(df)
+  df$prob_2pt <- ifelse(rows & !is.na(spread) & !is.na(total), p, NA_real_)
+  df
+}

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -628,3 +628,100 @@ NULL
   df$vegas_wp <- ifelse(is.na(spread_time), NA_real_, p)
   df
 }
+
+#' Expected-pass feature contract and the ORDINAL rule-era cuts
+#'
+#' `.XPASS_ERA_CUTS` is the **ordinal** `era` used by `xpass_model` and
+#' `two_pt_model` -- cuts 2006/2013/**2017**, encoded 0/1/2/3 in one column.
+#' It is NOT [.FG_ERA_CUTS], the one-hot `era0..era3` set used by
+#' `fg_model`/`fd_model`, whose third cut is **2020**. The two disagree over
+#' 2018-2020, so they are deliberately separate constants.
+#'
+#' @keywords internal
+#' @noRd
+.XPASS_ERA_CUTS <- c(2006, 2013, 2017)
+
+#' @rdname cfb_model_artifacts
+#' @keywords internal
+#' @noRd
+.XPASS_FEATURES <- c(
+  "down", "distance", "yards_to_goal", "pos_score_diff",
+  "TimeSecsRem", "era", "period"
+)
+
+#' Ordinal CFB rule era from season
+#'
+#' @return 0 (<=2006), 1 (<=2013), 2 (<=2017), 3 (later).
+#' @keywords internal
+#' @noRd
+.cfb_era_ordinal <- function(season, n) {
+  s <- suppressWarnings(as.numeric(season))
+  if (length(s) == 1L) s <- rep(s, n)
+  cuts <- .XPASS_ERA_CUTS
+  ifelse(s <= cuts[1], 0,
+         ifelse(s <= cuts[2], 1,
+                ifelse(s <= cuts[3], 2, 3)))
+}
+
+#' Lazily load the bundled expected-pass model
+#' @keywords internal
+#' @noRd
+.cfb_xpass_model <- function() {
+  if (!is.null(.cfb_model_env$xpass)) return(.cfb_model_env$xpass)
+  if (!requireNamespace("xgboost", quietly = TRUE)) return(NULL)
+  f <- .cfb_model_file("xpass_model.ubj")
+  if (is.null(f)) return(NULL)
+  b <- try(xgboost::xgb.load(f), silent = TRUE)
+  if (inherits(b, "try-error") || is.null(b)) return(NULL)
+  .cfb_model_env$xpass <- b
+  b
+}
+
+#' Append expected pass rate (`xpass`) and pass over expected (`pass_oe`)
+#'
+#' nflfastR's `xpass` / `pass_oe`, on scrimmage plays only, with `pass_oe` on
+#' the percentage-point scale `100 * (pass - xpass)`.
+#'
+#' Note the `pos_score_diff` feature is fed from **`pos_score_diff_start`**,
+#' the same sourcing subtlety as the CP model: cfbfastR carries a separate
+#' like-named `pos_score_diff` column holding a different value.
+#'
+#' Never raises; missing model, season or inputs yield all-`NA` columns.
+#'
+#' @param season Season of the game, needed for the ordinal era feature.
+#' @keywords internal
+#' @noRd
+.pbp_add_xpass <- function(df, season = NULL) {
+  df$xpass <- rep(NA_real_, nrow(df))
+  df$pass_oe <- rep(NA_real_, nrow(df))
+  need <- c("down", "distance", "yards_to_goal", "pos_score_diff_start",
+            "TimeSecsRem", "period", "pass", "rush")
+  if (!nrow(df) || !all(need %in% names(df))) return(df)
+  if (is.null(season) || all(is.na(season))) return(df)
+  model <- .cfb_xpass_model()
+  if (is.null(model)) return(df)
+
+  p <- try({
+    pick <- function(nm) suppressWarnings(as.numeric(as.character(df[[nm]])))
+    x <- cbind(
+      down = pick("down"),
+      distance = pick("distance"),
+      yards_to_goal = pick("yards_to_goal"),
+      # NOT df$pos_score_diff -- see the note above.
+      pos_score_diff = pick("pos_score_diff_start"),
+      TimeSecsRem = pick("TimeSecsRem"),
+      era = .cfb_era_ordinal(season, nrow(df)),
+      period = pick("period")
+    )
+    colnames(x) <- .XPASS_FEATURES
+    as.numeric(stats::predict(model, x))
+  }, silent = TRUE)
+  if (inherits(p, "try-error") || length(p) != nrow(df)) return(df)
+
+  pass <- suppressWarnings(as.numeric(as.character(df$pass)))
+  rush <- suppressWarnings(as.numeric(as.character(df$rush)))
+  scrimmage <- (pass %in% 1) | (rush %in% 1)
+  df$xpass <- ifelse(scrimmage, p, NA_real_)
+  df$pass_oe <- ifelse(scrimmage & !is.na(pass), 100 * (pass - df$xpass), NA_real_)
+  df
+}

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -1,0 +1,230 @@
+#' Shared CFB model artifacts (`cfb_model_artifacts` bundle)
+#'
+#' @description Fetch and score the models published in the
+#'   `cfb_model_artifacts` release, the single source of truth read by BOTH
+#'   `cfbfastR` and `sportsdataverse-py`. Publishing to that release is the one
+#'   change that updates both libraries.
+#'
+#' @details The historical EP model was an `nnet::multinom` downloaded from
+#'   `cfbfastR-data`. It aborts on mid-era CFBD data
+#'   (`predict.nnet(): missing values in 'x'`, seasons ~2006-2013; see issue #5)
+#'   and is a different generation from the models sdv-py scores with, so the
+#'   two libraries disagreed on EPA for the same play.
+#'
+#'   Everything here funnels through [`.ep_predict()`] so the eight historical
+#'   `predict(ep_model, ...)` call sites share one implementation of the
+#'   feature contract and the class-order permutation. Fixing the contract in
+#'   one place is the point -- a per-call-site fix would leave the next new
+#'   call site free to get it wrong.
+#'
+#' @name cfb_model_artifacts
+#' @keywords internal
+NULL
+
+#' @rdname cfb_model_artifacts
+#' @keywords internal
+#' @noRd
+.CFB_MODEL_BASE <- paste0(
+  "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/",
+  "cfb_model_artifacts/"
+)
+
+#' Process-lifetime cache for the manifest (and anything else bundle-scoped).
+#' @keywords internal
+#' @noRd
+.cfb_model_env <- new.env(parent = emptyenv())
+
+#' EP next-score class order, point values and feature contract
+#'
+#' `.EP_LEV` preserves the *historical* `ep_model$lev` ordering. Every
+#' downstream column name (`TD_before`, `Opp_FG_after`, ...) and the positional
+#' `weights <- c(0, 3, -3, -2, -7, 2, 7)` vector in [.pbp_create_epa()] are
+#' expressed in this order, so keeping it lets the model swap stay invisible to
+#' the rest of the pipeline.
+#'
+#' @keywords internal
+#' @noRd
+.EP_LEV <- c("No_Score", "FG", "Opp_FG", "Opp_Safety", "Opp_TD", "Safety", "TD")
+
+#' @rdname cfb_model_artifacts
+#' @keywords internal
+#' @noRd
+.EP_FEATURES <- c(
+  "TimeSecsRem", "yards_to_goal", "distance",
+  "down_1", "down_2", "down_3", "down_4", "pos_score_diff_start"
+)
+
+#' Fallback for the bundle's EP class permutation
+#'
+#' The authoritative value lives in the bundle's `MANIFEST.json`
+#' (`ep_class_contract$permutation_to_cfbfastR_lev_1based`) and is read from
+#' there by [.ep_class_permutation()]; this constant only covers the offline
+#' case. `test-ep_model_artifacts.R` asserts the two agree, so an upstream
+#' reordering cannot silently diverge from this copy.
+#'
+#' @keywords internal
+#' @noRd
+.EP_PERM_FALLBACK <- c(7L, 3L, 4L, 6L, 2L, 5L, 1L)
+
+#' Fetch a bundle asset to the on-disk model cache and return its path
+#'
+#' `xgboost::xgb.load()` reads a local file, not a URL, so the asset is
+#' downloaded first. The copy is cached under the package's user cache dir and
+#' re-downloaded once it is older than `cfbfastR.cache_duration` (default 24h) --
+#' that TTL is what makes "publish to the release once and both libraries pick
+#' it up" true without anyone editing code.
+#'
+#' @param asset File name within the release, e.g. `"ep_model.ubj"`.
+#' @return Local path, or `NULL` when the asset could not be fetched and no
+#'   usable cached copy exists.
+#' @keywords internal
+#' @noRd
+.cfb_model_file <- function(asset) {
+  dir <- file.path(tools::R_user_dir("cfbfastR", which = "cache"), "models")
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  dest <- file.path(dir, asset)
+
+  ttl <- getOption("cfbfastR.cache_duration", default = 86400)
+  fresh <- file.exists(dest) &&
+    difftime(Sys.time(), file.info(dest)$mtime, units = "secs") < ttl
+  if (fresh) return(dest)
+
+  tmp <- paste0(dest, ".part")
+  ok <- try(
+    utils::download.file(paste0(.CFB_MODEL_BASE, asset), tmp,
+                         mode = "wb", quiet = TRUE),
+    silent = TRUE
+  )
+  if (!inherits(ok, "try-error") && file.exists(tmp) && file.size(tmp) > 0) {
+    # Only replace the cached copy once the download is complete, so an
+    # interrupted fetch can't leave a truncated model in place.
+    file.rename(tmp, dest)
+    return(dest)
+  }
+  unlink(tmp)
+  # Stale beats absent: an expired cached copy still scores.
+  if (file.exists(dest)) dest else NULL
+}
+
+#' Download and cache the bundle manifest
+#'
+#' @return The parsed manifest, or `NULL` when it cannot be fetched (offline,
+#'   rate-limited, asset moved). Callers must degrade rather than abort --
+#'   a missing manifest is not a reason to refuse to score.
+#' @keywords internal
+#' @noRd
+.cfb_model_manifest <- function() {
+  if (!is.null(.cfb_model_env$manifest)) return(.cfb_model_env$manifest)
+  man <- try(
+    jsonlite::fromJSON(paste0(.CFB_MODEL_BASE, "MANIFEST.json"),
+                       simplifyVector = FALSE),
+    silent = TRUE
+  )
+  if (inherits(man, "try-error")) return(NULL)
+  .cfb_model_env$manifest <- man
+  man
+}
+
+#' Resolve the EP class permutation, manifest-first
+#'
+#' Maps the bundle's class order (`TD, Opp_TD, FG, Opp_FG, Safety, Opp_Safety,
+#' No_Score`) onto [.EP_LEV]. The two orderings share no fixed point, so
+#' applying the wrong one yields EP that is wrong yet lands in a plausible
+#' range -- it will not trip a sanity check. That is why this is read from the
+#' published manifest and validated rather than inlined at the call site.
+#'
+#' @keywords internal
+#' @noRd
+.ep_class_permutation <- function() {
+  man <- .cfb_model_manifest()
+  p <- try(
+    unlist(man$ep_class_contract$permutation_to_cfbfastR_lev_1based),
+    silent = TRUE
+  )
+  if (inherits(p, "try-error") || length(p) != 7L ||
+      !setequal(as.integer(p), 1:7)) {
+    return(.EP_PERM_FALLBACK)
+  }
+  as.integer(p)
+}
+
+#' Build the EP model's feature matrix
+#'
+#' The bundle's EP model takes one-hot `down_1..down_4` and *raw* `distance`.
+#' The retired `nnet` formula instead used a `down` factor plus `log_ydstogo`,
+#' `Goal_To_Go`, `Under_two` and interactions, so the caller's frame is
+#' translated here rather than passed through.
+#'
+#' @param newdata Frame carrying `TimeSecsRem`, `yards_to_goal`, `distance`,
+#'   `down` (factor, numeric or character) and `pos_score_diff_start`.
+#' @keywords internal
+#' @noRd
+.ep_feature_matrix <- function(newdata) {
+  need <- c("TimeSecsRem", "yards_to_goal", "distance", "down",
+            "pos_score_diff_start")
+  missing_cols <- setdiff(need, names(newdata))
+  if (length(missing_cols)) {
+    cli::cli_abort(c(
+      "EP scoring frame is missing required column{?s}: {.field {missing_cols}}.",
+      i = "The bundled EP model needs {.field {need}}."
+    ))
+  }
+  # as.character() first: as.numeric() on a factor yields its integer CODES,
+  # which silently mislabels down whenever the levels are not 1:4 in order.
+  down <- suppressWarnings(as.numeric(as.character(newdata$down)))
+  m <- cbind(
+    TimeSecsRem = as.numeric(newdata$TimeSecsRem),
+    yards_to_goal = as.numeric(newdata$yards_to_goal),
+    distance = as.numeric(newdata$distance),
+    down_1 = as.numeric(down == 1),
+    down_2 = as.numeric(down == 2),
+    down_3 = as.numeric(down == 3),
+    down_4 = as.numeric(down == 4),
+    pos_score_diff_start = as.numeric(newdata$pos_score_diff_start)
+  )
+  colnames(m) <- .EP_FEATURES
+  m
+}
+
+#' Score the EP model, whichever generation is loaded
+#'
+#' Single entry point for every EP prediction in the package. Returns a
+#' `data.frame` of seven next-score probabilities named and **ordered** by
+#' [.EP_LEV], regardless of which model generation is in hand -- so callers can
+#' keep applying the positional `weights` vector unchanged.
+#'
+#' @param ep_model Either the bundle's `xgb.Booster` or a legacy
+#'   `nnet::multinom` (still accepted so a cached old artifact keeps working).
+#' @param newdata One row per play.
+#' @return `data.frame`, `nrow(newdata)` x 7, columns named [.EP_LEV].
+#' @keywords internal
+#' @noRd
+.ep_predict <- function(ep_model, newdata) {
+  if (!inherits(ep_model, "xgb.Booster")) {
+    # Legacy nnet::multinom path, preserved verbatim.
+    out <- as.data.frame(stats::predict(ep_model, newdata, type = "prob"))
+    if (ncol(out) == 1L) out <- as.data.frame(t(out))
+    colnames(out) <- ep_model$lev
+    return(out)
+  }
+
+  rlang::check_installed("xgboost", reason = "to score the bundled EP model.")
+  x <- .ep_feature_matrix(newdata)
+  p <- stats::predict(ep_model, x)
+
+  # multi:softprob returns either an n x 7 matrix or a flat row-major vector
+  # depending on the xgboost version. Reshape byrow so class probabilities stay
+  # attached to their own play -- column-major would silently interleave rows.
+  if (!is.matrix(p) || ncol(p) != length(.EP_LEV)) {
+    p <- matrix(as.numeric(p), ncol = length(.EP_LEV), byrow = TRUE)
+  }
+  if (nrow(p) != nrow(x)) {
+    cli::cli_abort(
+      "EP model returned {nrow(p)} row{?s} for {nrow(x)} play{?s}."
+    )
+  }
+
+  p <- p[, .ep_class_permutation(), drop = FALSE]
+  colnames(p) <- .EP_LEV
+  as.data.frame(p)
+}

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -442,3 +442,93 @@ NULL
   df$cpoe <- ifelse(is_pass & !is.na(comp), 100 * (comp - df$cp), NA_real_)
   df
 }
+
+#' Field-goal model feature contract and rule-era cuts
+#'
+#' The bundled `fg_model` is era-aware: `yards_to_goal` plus one-hot rule-era
+#' dummies. The retired model was a single-feature `mgcv::bam`
+#' (`fg_made ~ 1 + yards_to_goal`), so era is new information the frame has to
+#' supply.
+#'
+#' **These cuts (2006/2013/2020) are the ONE-HOT `era0..era3` cuts used by
+#' `fg_model` and `fd_model`.** sdv-py also carries a distinct *ordinal* `era`
+#' with cuts 2006/2013/**2017** for `xpass_model` / `two_pt_model`. The two are
+#' not interchangeable; conflating them silently mis-labels the 2018-2020
+#' seasons.
+#'
+#' @keywords internal
+#' @noRd
+.FG_ERA_CUTS <- c(2006, 2013, 2020)
+
+#' @rdname cfb_model_artifacts
+#' @keywords internal
+#' @noRd
+.FG_FEATURES <- c("yards_to_goal", "era0", "era1", "era2", "era3")
+
+#' Feature names of a booster, across xgboost API generations
+#'
+#' xgboost 3.x exposes these via `getinfo(m, "feature_name")`; the older
+#' `m$feature_names` handle attribute comes back empty there and would make a
+#' contract check silently pass on an empty set.
+#'
+#' @keywords internal
+#' @noRd
+.booster_feature_names <- function(model) {
+  fn <- try(xgboost::getinfo(model, "feature_name"), silent = TRUE)
+  if (inherits(fn, "try-error") || !length(fn)) fn <- model$feature_names
+  as.character(fn %||% character())
+}
+
+#' One-hot CFB rule-era dummies from season
+#'
+#' @param season Scalar or length-`n` season; recycled to `n` rows.
+#' @param n Number of rows to emit.
+#' @keywords internal
+#' @noRd
+.cfb_era_onehot <- function(season, n) {
+  s <- suppressWarnings(as.numeric(season))
+  if (length(s) == 1L) s <- rep(s, n)
+  lo <- .FG_ERA_CUTS[1]; mid <- .FG_ERA_CUTS[2]; hi <- .FG_ERA_CUTS[3]
+  cbind(
+    era0 = as.numeric(s <= lo),
+    era1 = as.numeric(s > lo & s <= mid),
+    era2 = as.numeric(s > mid & s <= hi),
+    era3 = as.numeric(s > hi)
+  )
+}
+
+#' Field-goal make probability, whichever model generation is loaded
+#'
+#' @param fg_mod The bundle's `xgb.Booster`, or the retired `mgcv::bam`.
+#' @param newdata Frame carrying `yards_to_goal`.
+#' @param season Season of the game, required when the loaded model declares
+#'   era features.
+#' @return Numeric make-probability, `nrow(newdata)` long.
+#' @keywords internal
+#' @noRd
+.fg_make_prob <- function(fg_mod, newdata, season = NULL) {
+  if (!inherits(fg_mod, "xgb.Booster")) {
+    return(as.numeric(mgcv::predict.bam(fg_mod, newdata = newdata,
+                                        type = "response")))
+  }
+  rlang::check_installed("xgboost", reason = "to score the bundled FG model.")
+  fnames <- .booster_feature_names(fg_mod)
+  if (!length(fnames)) fnames <- "yards_to_goal"
+
+  x <- cbind(yards_to_goal = as.numeric(newdata$yards_to_goal))
+  if (any(startsWith(fnames, "era"))) {
+    # Fail loudly rather than defaulting season: an absent season would make
+    # every era dummy 0, which is not a valid one-hot and silently shifts every
+    # field-goal probability. sdv-py raises here for the same reason.
+    if (is.null(season) || all(is.na(season))) {
+      cli::cli_abort(c(
+        "The bundled era-aware FG model requires {.arg season}.",
+        x = "Without it the era features would all be zero and quietly skew every FG probability.",
+        i = "Pass {.arg season} through {.fn .run_epa_wpa}."
+      ))
+    }
+    x <- cbind(x, .cfb_era_onehot(season, nrow(newdata)))
+  }
+  keep <- intersect(fnames, colnames(x))
+  as.numeric(stats::predict(fg_mod, x[, keep, drop = FALSE]))
+}

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -415,6 +415,17 @@ NULL
 #' required inputs yields all-`NA` columns, so the surface is safe to run
 #' unconditionally in the pipeline.
 #'
+#' **Interpreting `cpoe` before ~2014.** ESPN's early play-by-play does not
+#' label sacks: 2013 week 1 carries 5 across 13,800 plays, against ~337 per
+#' week from 2018 on. A sack is a pass play with no completion, so its absence
+#' inflates the observed completion rate and pushes league-wide `cpoe` roughly
+#' +6 percentage points in those seasons (2013 wk1 +5.9pp and wk8 +6.7pp,
+#' against +0.05pp in 2018 and +0.54pp in 2021). This is an upstream
+#' data-coverage artefact rather than a model or scoring error -- mean `cp`
+#' itself is stable at ~0.566 in every era, and excluding sacks the completion
+#' rates converge (0.626 / 0.601 / 0.605). Treat early-era `cpoe` as
+#' non-comparable to the modern era, not as better quarterback play.
+#'
 #' @keywords internal
 #' @noRd
 .pbp_add_cp_cpoe <- function(df) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -84,16 +84,43 @@
     }
   }
 }
-load_ep_model <- function(){
+#' Load the Expected Points model
+#'
+#' Fetches `ep_model.ubj` from the shared `cfb_model_artifacts` release -- the
+#' same artifact `sportsdataverse-py` scores with, so both libraries agree on
+#' EPA and a retrain updates both in one publish.
+#'
+#' Falls back to the retired `nnet::multinom` on `cfbfastR-data` when the
+#' bundle or `xgboost` is unavailable, so an offline session still returns a
+#' usable model. [`.ep_predict()`] accepts either generation. Note the legacy
+#' model aborts on mid-era CFBD data (issue #5); the bundled model does not.
+#'
+#' @keywords internal
+#' @noRd
+load_ep_model <- function() {
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    f <- .cfb_model_file("ep_model.ubj")
+    if (!is.null(f)) {
+      booster <- try(xgboost::xgb.load(f), silent = TRUE)
+      if (!inherits(booster, "try-error") && !is.null(booster)) return(booster)
+    }
+  }
+  .load_legacy_ep_model()
+}
+
+#' Retired nnet EP model, kept as the offline/no-xgboost fallback
+#' @keywords internal
+#' @noRd
+.load_legacy_ep_model <- function() {
   ep_model <- NULL
   # load the model from GitHub because it is too large for the package
-  .url = url("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/models/ep_model.Rdata")
+  .url <- url("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/models/ep_model.Rdata")
   on.exit(close(.url))
   try(
     load(.url),
     silent = TRUE
   )
-  return (ep_model)
+  return(ep_model)
 }
 load_fg_model <- function(){
   fg_model <- NULL

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -132,14 +132,37 @@ load_fg_model <- function(){
   )
   return (fg_model)
 }
-load_wp_model <- function(){
+#' Load the Win Probability model
+#'
+#' Prefers `wp_naive.ubj` from the shared `cfb_model_artifacts` release, the
+#' same artifact `sportsdataverse-py` scores with. Falls back to the retired
+#' `mgcv::bam` GAM on `cfbfastR-data` when the bundle or `xgboost` is
+#' unavailable; [`.wp_predict()`] accepts either generation.
+#'
+#' @keywords internal
+#' @noRd
+load_wp_model <- function() {
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    f <- .cfb_model_file("wp_naive.ubj")
+    if (!is.null(f)) {
+      booster <- try(xgboost::xgb.load(f), silent = TRUE)
+      if (!inherits(booster, "try-error") && !is.null(booster)) return(booster)
+    }
+  }
+  .load_legacy_wp_model()
+}
+
+#' Retired mgcv GAM WP model, kept as the offline/no-xgboost fallback
+#' @keywords internal
+#' @noRd
+.load_legacy_wp_model <- function() {
   wp_model <- NULL
-  .url = url("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/models/wp_model.Rdata")
+  .url <- url("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/models/wp_model.Rdata")
   on.exit(close(.url))
   try(
     load(.url),
     silent = TRUE
   )
-  return (wp_model)
+  return(wp_model)
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -122,15 +122,37 @@ load_ep_model <- function() {
   )
   return(ep_model)
 }
-load_fg_model <- function(){
+#' Load the Field Goal model
+#'
+#' Prefers the era-aware `fg_model.ubj` from the shared `cfb_model_artifacts`
+#' release; falls back to the retired single-feature `mgcv::bam` when the
+#' bundle or `xgboost` is unavailable. [`.fg_make_prob()`] scores either.
+#'
+#' @keywords internal
+#' @noRd
+load_fg_model <- function() {
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    f <- .cfb_model_file("fg_model.ubj")
+    if (!is.null(f)) {
+      booster <- try(xgboost::xgb.load(f), silent = TRUE)
+      if (!inherits(booster, "try-error") && !is.null(booster)) return(booster)
+    }
+  }
+  .load_legacy_fg_model()
+}
+
+#' Retired single-feature GAM FG model, kept as the offline fallback
+#' @keywords internal
+#' @noRd
+.load_legacy_fg_model <- function() {
   fg_model <- NULL
-  .url = url("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/models/fg_model.Rdata")
+  .url <- url("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/models/fg_model.Rdata")
   on.exit(close(.url))
   try(
     load(.url),
     silent = TRUE
   )
-  return (fg_model)
+  return(fg_model)
 }
 #' Load the Win Probability model
 #'

--- a/man/create_epa.Rd
+++ b/man/create_epa.Rd
@@ -5,9 +5,9 @@
 \alias{epa_fg_probs}
 \title{\strong{Create EPA}}
 \usage{
-create_epa(play_df, ep_model, fg_model)
+create_epa(play_df, ep_model, fg_model, season = NULL)
 
-epa_fg_probs(dat, current_probs, ep_model, fg_mod)
+epa_fg_probs(dat, current_probs, ep_model, fg_mod, season = NULL)
 }
 \arguments{
 \item{play_df}{(\emph{data.frame} required): Clean PBP as input from \code{\link[=cfbd_pbp_data]{cfbd_pbp_data()}}}
@@ -15,6 +15,9 @@ epa_fg_probs(dat, current_probs, ep_model, fg_mod)
 \item{ep_model}{(\strong{model}, default \code{cfbfastR}'s \code{ep_model}): FG Model to be used for prediction on field goal (FG) attempts in Play-by-Play data.frame}
 
 \item{fg_model}{(\emph{model} default \code{cfbfastR}'s \code{fg_model}): Field Goal (FG) Model}
+
+\item{season}{(\emph{numeric} optional): Season of the game, required when the
+loaded FG model is era-aware. See \code{\link[=create_epa]{create_epa()}}.}
 
 \item{dat}{(\strong{data.frame} required): Clean Play-By-Play data.frame as can be pulled from \code{\link[=clean_pbp_dat]{clean_pbp_dat()}}}
 

--- a/tests/testthat/test-cp_model_artifacts.R
+++ b/tests/testthat/test-cp_model_artifacts.R
@@ -1,0 +1,121 @@
+### Gates for the bundled completion-probability model (issue #138 P3).
+###
+### The load-bearing risk here is the `score_diff` feature: the bundle feeds it
+### from `pos_score_diff_start`, but cfbfastR ALSO has a column literally named
+### `score_diff` with a different value. Reading the like-named one yields
+### completion probabilities that are wrong and entirely plausible.
+
+test_that(".CP_FEATURES matches the bundle contract", {
+  expect_identical(
+    .CP_FEATURES,
+    c("down", "distance", "yards_to_goal", "score_diff",
+      "seconds_remaining", "is_home", "period", "passing_down")
+  )
+})
+
+test_that("cp score_diff is sourced from pos_score_diff_start, not score_diff", {
+  # The two differ in real data; this pins which one the model gets.
+  df <- data.frame(
+    down = 1, distance = 10, yards_to_goal = 60,
+    pos_score_diff_start = -7, score_diff = 21,   # deliberately different
+    TimeSecsRem = 900, period = 2,
+    pos_team = "A", home = "A", pass = 1, rush = 0, completion = 1
+  )
+  m <- .cp_feature_matrix(df)
+  expect_equal(unname(m[, "score_diff"]), -7)
+  expect_false(identical(unname(m[, "score_diff"]), 21))
+})
+
+test_that(".cp_passing_down implements the 2nd&8 / 3rd&5 / 4th&5 rule", {
+  df <- data.frame(
+    down     = c(1, 2, 2, 3, 3, 4, 4, 2),
+    distance = c(10, 8, 7, 5, 4, 5, 4, 20),
+    pass     = c(1, 1, 1, 1, 1, 1, 1, 0),
+    rush     = c(0, 0, 0, 0, 0, 0, 0, 1)
+  )
+  expect_equal(.cp_passing_down(df), c(0, 1, 0, 1, 0, 1, 0, 1))
+})
+
+test_that(".cp_passing_down excludes non-scrimmage plays", {
+  # A punt or kickoff on 4th & long is not a passing down.
+  df <- data.frame(down = 4, distance = 10, pass = 0, rush = 0)
+  expect_equal(.cp_passing_down(df), 0)
+  # Unclassified play (NA) must not become a passing down either.
+  df2 <- data.frame(down = 3, distance = 10,
+                    pass = NA_real_, rush = NA_real_)
+  expect_equal(.cp_passing_down(df2), 0)
+})
+
+test_that(".cp_feature_matrix builds all eight features in contract order", {
+  df <- data.frame(
+    down = c(1, 3), distance = c(10, 6), yards_to_goal = c(75, 40),
+    pos_score_diff_start = c(0, -3), score_diff = c(0, 3),
+    TimeSecsRem = c(1800, 300), period = c(1, 4),
+    pos_team = c("A", "B"), home = c("A", "A"),
+    pass = c(1, 1), rush = c(0, 0), completion = c(1, 0)
+  )
+  m <- .cp_feature_matrix(df)
+  expect_identical(colnames(m), .CP_FEATURES)
+  expect_equal(nrow(m), 2L)
+  expect_equal(unname(m[, "is_home"]), c(1, 0))
+  expect_equal(unname(m[, "passing_down"]), c(0, 1))
+  expect_equal(unname(m[, "seconds_remaining"]), c(1800, 300))
+  expect_false(anyNA(m))
+})
+
+test_that(".pbp_add_cp_cpoe degrades to NA columns instead of raising", {
+  # Contract match with sdv-py: a frame lacking model inputs must still come
+  # back with the columns present, so the pipeline can run unconditionally.
+  df <- data.frame(down = 1, distance = 10)
+  out <- .pbp_add_cp_cpoe(df)
+  expect_true(all(c("cp", "cpoe") %in% names(out)))
+  expect_true(is.na(out$cp))
+  expect_true(is.na(out$cpoe))
+  expect_equal(nrow(out), 1L)
+})
+
+test_that(".pbp_add_cp_cpoe handles a zero-row frame", {
+  df <- data.frame(down = numeric(0), distance = numeric(0),
+                   yards_to_goal = numeric(0), pos_score_diff_start = numeric(0),
+                   TimeSecsRem = numeric(0), period = numeric(0),
+                   pass = numeric(0), completion = numeric(0))
+  out <- .pbp_add_cp_cpoe(df)
+  expect_equal(nrow(out), 0L)
+  expect_true(all(c("cp", "cpoe") %in% names(out)))
+})
+
+test_that("the published manifest agrees with the in-package CP contract", {
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+  expect_identical(unlist(man$assets$cfb_cp_model.ubj$features), .CP_FEATURES)
+})
+
+test_that("cp/cpoe are populated on pass plays only and on the right scale", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  skip_if(is.null(.cfb_cp_model()), "bundled CP model unavailable")
+
+  df <- data.frame(
+    down = c(1, 2, 3), distance = c(10, 8, 5),
+    yards_to_goal = c(75, 50, 30), pos_score_diff_start = c(0, -7, 3),
+    TimeSecsRem = c(1800, 900, 200), period = c(1, 2, 4),
+    pos_team = c("A", "A", "B"), home = c("A", "A", "A"),
+    pass = c(1, 0, 1), rush = c(0, 1, 0),      # middle play is a run
+    completion = c(1, NA, 0)
+  )
+  out <- .pbp_add_cp_cpoe(df)
+
+  expect_false(is.na(out$cp[1]))
+  expect_true(is.na(out$cp[2]))               # run play -> no cp
+  expect_false(is.na(out$cp[3]))
+  expect_true(all(out$cp[c(1, 3)] >= 0 & out$cp[c(1, 3)] <= 1))
+
+  # cpoe is percentage points: a completion scores positive, an incompletion
+  # negative, and the magnitude tracks 100*(completion - cp).
+  expect_equal(out$cpoe[1], 100 * (1 - out$cp[1]))
+  expect_equal(out$cpoe[3], 100 * (0 - out$cp[3]))
+  expect_gt(out$cpoe[1], 0)
+  expect_lt(out$cpoe[3], 0)
+  expect_true(is.na(out$cpoe[2]))
+})

--- a/tests/testthat/test-cp_model_artifacts.R
+++ b/tests/testthat/test-cp_model_artifacts.R
@@ -85,6 +85,7 @@ test_that(".pbp_add_cp_cpoe handles a zero-row frame", {
 })
 
 test_that("the published manifest agrees with the in-package CP contract", {
+  skip_on_cran()
   skip_if_offline()
   man <- .cfb_model_manifest()
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
@@ -92,6 +93,7 @@ test_that("the published manifest agrees with the in-package CP contract", {
 })
 
 test_that("cp/cpoe are populated on pass plays only and on the right scale", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   skip_if(is.null(.cfb_cp_model()), "bundled CP model unavailable")

--- a/tests/testthat/test-ep_model_artifacts.R
+++ b/tests/testthat/test-ep_model_artifacts.R
@@ -61,6 +61,7 @@ test_that(".ep_feature_matrix refuses a frame missing model columns", {
 })
 
 test_that("the published manifest agrees with the in-package fallback", {
+  skip_on_cran()
   skip_if_offline()
   man <- .cfb_model_manifest()
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
@@ -78,6 +79,7 @@ test_that("the published manifest agrees with the in-package fallback", {
 })
 
 test_that(".ep_predict returns lev-ordered probabilities that keep rows intact", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   ep_model <- load_ep_model()
@@ -113,6 +115,7 @@ test_that(".ep_predict returns lev-ordered probabilities that keep rows intact",
 })
 
 test_that("a wrong class permutation would be caught by the sanity gate", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   ep_model <- load_ep_model()

--- a/tests/testthat/test-ep_model_artifacts.R
+++ b/tests/testthat/test-ep_model_artifacts.R
@@ -1,0 +1,134 @@
+### Gates for the shared `cfb_model_artifacts` EP model (issue #138 P1).
+###
+### The class-order gate is the important one. cfbfastR's historical
+### `ep_model$lev` order and the bundle's class order share NO fixed point, so
+### scoring with the wrong permutation produces EP that is wrong but lands in a
+### plausible range -- it will not trip a range check or an eyeball. Every test
+### here is written to fail loudly if that mapping drifts.
+
+test_that(".EP_LEV still matches the weights vector it is scored against", {
+  # `weights <- c(0, 3, -3, -2, -7, 2, 7)` in .pbp_create_epa() is positional.
+  # If .EP_LEV is ever reordered without reordering the weights, EPA silently
+  # becomes garbage -- so pin the pairing explicitly.
+  expect_identical(
+    .EP_LEV,
+    c("No_Score", "FG", "Opp_FG", "Opp_Safety", "Opp_TD", "Safety", "TD")
+  )
+  points <- c(No_Score = 0, FG = 3, Opp_FG = -3, Opp_Safety = -2,
+              Opp_TD = -7, Safety = 2, TD = 7)
+  expect_identical(unname(points[.EP_LEV]), c(0, 3, -3, -2, -7, 2, 7))
+})
+
+test_that(".EP_PERM_FALLBACK is a valid permutation that reproduces the weights", {
+  expect_setequal(.EP_PERM_FALLBACK, 1:7)
+  # Bundle order and its point values, per MANIFEST.json's ep_class_contract.
+  bundle_points <- c(7, -7, 3, -3, 2, -2, 0)   # TD, Opp_TD, FG, Opp_FG, Sfty, Opp_Sfty, None
+  expect_identical(bundle_points[.EP_PERM_FALLBACK], c(0, 3, -3, -2, -7, 2, 7))
+})
+
+test_that(".ep_feature_matrix builds the bundle's contract in order", {
+  nd <- data.frame(
+    TimeSecsRem = c(1800, 300),
+    yards_to_goal = c(75, 20),
+    distance = c(10, 3),
+    down = factor(c(1, 3), levels = c("1", "2", "3", "4")),
+    pos_score_diff_start = c(0, -7)
+  )
+  m <- .ep_feature_matrix(nd)
+  expect_identical(colnames(m), .EP_FEATURES)
+  expect_equal(nrow(m), 2L)
+  # one-hot down, exactly one hot per row
+  expect_equal(unname(rowSums(m[, c("down_1", "down_2", "down_3", "down_4")])), c(1, 1))
+  expect_equal(unname(m[1, "down_1"]), 1)
+  expect_equal(unname(m[2, "down_3"]), 1)
+})
+
+test_that(".ep_feature_matrix reads down VALUES, not factor level codes", {
+  # as.numeric() on a factor returns level codes. With reversed levels that
+  # turns 1st down into 4th down -- a silent, plausible-looking corruption.
+  a <- data.frame(TimeSecsRem = 900, yards_to_goal = 60, distance = 10,
+                  down = factor("1", levels = c("1", "2", "3", "4")),
+                  pos_score_diff_start = 0)
+  b <- a
+  b$down <- factor("1", levels = c("4", "3", "2", "1"))
+  expect_identical(.ep_feature_matrix(a), .ep_feature_matrix(b))
+  expect_equal(unname(.ep_feature_matrix(b)[1, "down_1"]), 1)
+})
+
+test_that(".ep_feature_matrix refuses a frame missing model columns", {
+  nd <- data.frame(TimeSecsRem = 900, yards_to_goal = 60, down = 1)
+  expect_error(.ep_feature_matrix(nd), "distance")
+})
+
+test_that("the published manifest agrees with the in-package fallback", {
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+
+  ep <- man$ep_class_contract
+  expect_identical(unlist(ep$cfbfastR_lev_order), .EP_LEV)
+  expect_identical(as.integer(unlist(ep$permutation_to_cfbfastR_lev_1based)),
+                   .EP_PERM_FALLBACK)
+  # the manifest's own numbers must be self-consistent
+  expect_equal(
+    as.numeric(unlist(ep$point_values))[.EP_PERM_FALLBACK],
+    c(0, 3, -3, -2, -7, 2, 7)
+  )
+  expect_identical(unlist(man$assets$ep_model.ubj$features), .EP_FEATURES)
+})
+
+test_that(".ep_predict returns lev-ordered probabilities that keep rows intact", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  ep_model <- load_ep_model()
+  skip_if(!inherits(ep_model, "xgb.Booster"), "bundled EP model unavailable")
+
+  nd <- data.frame(
+    TimeSecsRem = c(1800, 120, 600, 30),
+    yards_to_goal = c(75, 5, 50, 95),
+    distance = c(10, 2, 7, 10),
+    down = factor(c(1, 3, 2, 4), levels = c("1", "2", "3", "4")),
+    pos_score_diff_start = c(0, -3, 7, -14)
+  )
+  p <- .ep_predict(ep_model, nd)
+
+  expect_s3_class(p, "data.frame")
+  expect_identical(colnames(p), .EP_LEV)
+  expect_equal(nrow(p), nrow(nd))
+  expect_true(all(abs(rowSums(p) - 1) < 1e-6))
+
+  # Batch scoring must equal row-by-row: catches a byrow/bycol reshape error,
+  # which would scramble probabilities across plays without changing sums.
+  alone <- do.call(rbind, lapply(seq_len(nrow(nd)), function(i) {
+    .ep_predict(ep_model, nd[i, , drop = FALSE])
+  }))
+  expect_equal(as.matrix(p), as.matrix(alone), tolerance = 1e-12)
+
+  # Football sanity, which a wrong permutation fails: 3rd & 2 at the 5 is worth
+  # far more than 4th & 10 from your own 5 while down two scores.
+  ep <- as.numeric(as.matrix(p) %*% c(0, 3, -3, -2, -7, 2, 7))
+  expect_gt(ep[2], 3)
+  expect_lt(ep[4], 0)
+  expect_gt(ep[2], ep[1])
+})
+
+test_that("a wrong class permutation would be caught by the sanity gate", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  ep_model <- load_ep_model()
+  skip_if(!inherits(ep_model, "xgb.Booster"), "bundled EP model unavailable")
+
+  nd <- data.frame(TimeSecsRem = 1800, yards_to_goal = 75, distance = 10,
+                   down = factor("1", levels = c("1", "2", "3", "4")),
+                   pos_score_diff_start = 0)
+  raw <- stats::predict(ep_model, .ep_feature_matrix(nd))
+  raw <- matrix(as.numeric(raw), ncol = 7, byrow = TRUE)
+
+  correct <- sum(raw * c(7, -7, 3, -3, 2, -2, 0))          # bundle order
+  naive <- sum(raw * c(0, 3, -3, -2, -7, 2, 7))            # cfbfastR weights, unpermuted
+  # Both are small positives -- which is exactly why this needs a test rather
+  # than a range check -- but they are NOT the same number.
+  expect_false(isTRUE(all.equal(correct, naive)))
+  expect_equal(sum(as.numeric(.ep_predict(ep_model, nd)) * c(0, 3, -3, -2, -7, 2, 7)),
+               correct, tolerance = 1e-9)
+})

--- a/tests/testthat/test-fg_model_artifacts.R
+++ b/tests/testthat/test-fg_model_artifacts.R
@@ -34,6 +34,7 @@ test_that(".cfb_era_onehot recycles a scalar season across rows", {
 })
 
 test_that("the era-aware FG model refuses to score without a season", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   fg <- load_fg_model()
@@ -48,6 +49,7 @@ test_that("the era-aware FG model refuses to score without a season", {
 })
 
 test_that("FG make probability falls with distance and stays in [0,1]", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   fg <- load_fg_model()
@@ -64,6 +66,7 @@ test_that("FG make probability falls with distance and stays in [0,1]", {
 })
 
 test_that("era actually moves the FG prediction", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   fg <- load_fg_model()
@@ -79,6 +82,7 @@ test_that("era actually moves the FG prediction", {
 })
 
 test_that("the published manifest agrees with the in-package FG contract", {
+  skip_on_cran()
   skip_if_offline()
   man <- .cfb_model_manifest()
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
@@ -91,6 +95,7 @@ test_that("every entry point forwards season to the era-aware FG model", {
   # every FG/XP play aborted in .fg_make_prob() and the outer handler swallowed
   # it -- the game came back with no modeled EPA at all. Validating only the v2
   # paths is what let that through, so all four are exercised here.
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   fg <- load_fg_model()

--- a/tests/testthat/test-fg_model_artifacts.R
+++ b/tests/testthat/test-fg_model_artifacts.R
@@ -117,3 +117,39 @@ test_that("every entry point forwards season to the era-aware FG model", {
     expect_gt(sum(is.finite(r$EPA)), 100)
   }
 })
+
+test_that(".cfb_season_or_date prefers a resolved season", {
+  expect_equal(.cfb_season_or_date(2021, "2022-01-10T00:00Z"), 2021)
+  expect_equal(.cfb_season_or_date(c(2019, 2019), NULL), c(2019, 2019))
+})
+
+test_that(".cfb_season_or_date derives the season from the game date", {
+  # An unresolved meta$season would otherwise abort FG scoring and hand back a
+  # silently unmodeled game.
+  expect_equal(.cfb_season_or_date(NA, "2021-09-04T23:30Z"), 2021)
+  # January bowl and playoff games belong to the PREVIOUS season -- the same
+  # August cut most_recent_cfb_season() uses.
+  expect_equal(.cfb_season_or_date(NA, "2022-01-10T00:00Z"), 2021)
+  expect_equal(.cfb_season_or_date(NA_integer_, "2021-12-31"), 2021)
+  expect_equal(.cfb_season_or_date(NA, "2021-07-15"), 2020)
+})
+
+test_that(".cfb_season_or_date returns NA rather than inventing a season", {
+  # Fabricating one would produce a valid-looking era one-hot and quietly skew
+  # every field-goal probability -- the failure the hard error exists to catch.
+  expect_true(is.na(.cfb_season_or_date(NA, NULL)))
+  expect_true(is.na(.cfb_season_or_date(NA, NA)))
+  expect_true(is.na(.cfb_season_or_date(NA, "not-a-date")))
+})
+
+test_that("an unavailable bundled model is not re-fetched on every call", {
+  # A season sweep calls these once per game; without negative caching a
+  # failing artifact re-downloads (and re-times-out) for every game.
+  old <- .cfb_model_env$unavailable
+  on.exit(.cfb_model_env$unavailable <- old, add = TRUE)
+  .cfb_model_env$unavailable <- list(cp_model = TRUE)
+  cached <- .cfb_model_env$cp_model
+  .cfb_model_env$cp_model <- NULL
+  on.exit(.cfb_model_env$cp_model <- cached, add = TRUE)
+  expect_null(.cfb_cp_model())
+})

--- a/tests/testthat/test-fg_model_artifacts.R
+++ b/tests/testthat/test-fg_model_artifacts.R
@@ -1,0 +1,86 @@
+### Gates for the era-aware bundled FG model (issue #138 P3).
+###
+### Two traps here. (1) An absent season makes every era dummy 0 -- not a valid
+### one-hot -- which shifts every field-goal probability without erroring.
+### (2) sdv-py carries TWO era definitions: the one-hot era0..era3 used by
+### fg_model/fd_model cuts at 2006/2013/2020, while the ORDINAL `era` used by
+### xpass/two_pt cuts at 2006/2013/2017. Conflating them mislabels 2018-2020.
+
+test_that("FG era cuts are the one-hot set, not the ordinal set", {
+  expect_identical(.FG_ERA_CUTS, c(2006, 2013, 2020))
+  # 2018 is the season that distinguishes the two definitions: era2 under the
+  # one-hot cuts, but ordinal-era 3 under the 2017 cut.
+  expect_equal(unname(.cfb_era_onehot(2018, 1)[1, ]), c(0, 0, 1, 0))
+})
+
+test_that(".cfb_era_onehot is a valid one-hot at every boundary", {
+  seasons <- c(1999, 2006, 2007, 2013, 2014, 2020, 2021, 2026)
+  m <- .cfb_era_onehot(seasons, length(seasons))
+  expect_identical(colnames(m), c("era0", "era1", "era2", "era3"))
+  expect_equal(unname(rowSums(m)), rep(1, length(seasons)))
+  # boundaries are inclusive on the lower era
+  expect_equal(unname(m[seasons == 2006, ]), c(1, 0, 0, 0))
+  expect_equal(unname(m[seasons == 2007, ]), c(0, 1, 0, 0))
+  expect_equal(unname(m[seasons == 2013, ]), c(0, 1, 0, 0))
+  expect_equal(unname(m[seasons == 2014, ]), c(0, 0, 1, 0))
+  expect_equal(unname(m[seasons == 2020, ]), c(0, 0, 1, 0))
+  expect_equal(unname(m[seasons == 2021, ]), c(0, 0, 0, 1))
+})
+
+test_that(".cfb_era_onehot recycles a scalar season across rows", {
+  m <- .cfb_era_onehot(2019, 3)
+  expect_equal(nrow(m), 3L)
+  expect_equal(unname(rowSums(m)), rep(1, 3))
+})
+
+test_that("the era-aware FG model refuses to score without a season", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  fg <- load_fg_model()
+  skip_if(!inherits(fg, "xgb.Booster"), "bundled FG model unavailable")
+  skip_if(!any(startsWith(.booster_feature_names(fg), "era")),
+          "loaded FG model is not era-aware")
+
+  d <- data.frame(yards_to_goal = c(20, 30))
+  # Silently scoring with all-zero era dummies is the failure mode this guards.
+  expect_error(.fg_make_prob(fg, d, season = NULL), "season")
+  expect_error(.fg_make_prob(fg, d, season = NA), "season")
+})
+
+test_that("FG make probability falls with distance and stays in [0,1]", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  fg <- load_fg_model()
+  skip_if(!inherits(fg, "xgb.Booster"), "bundled FG model unavailable")
+
+  d <- data.frame(yards_to_goal = c(2, 10, 20, 30, 40))
+  p <- .fg_make_prob(fg, d, season = 2021)
+  expect_length(p, 5L)
+  expect_true(all(p >= 0 & p <= 1))
+  # A chip shot must beat a long attempt. Not strict monotonicity at every
+  # step -- a tree model can plateau -- but the endpoints must order.
+  expect_gt(p[1], p[5])
+  expect_gt(p[1], 0.9)
+})
+
+test_that("era actually moves the FG prediction", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  fg <- load_fg_model()
+  skip_if(!inherits(fg, "xgb.Booster"), "bundled FG model unavailable")
+  skip_if(!any(startsWith(.booster_feature_names(fg), "era")),
+          "loaded FG model is not era-aware")
+
+  d <- data.frame(yards_to_goal = 35)
+  old <- .fg_make_prob(fg, d, season = 2004)
+  new <- .fg_make_prob(fg, d, season = 2024)
+  # If these were equal the era features would not be reaching the booster.
+  expect_false(isTRUE(all.equal(old, new)))
+})
+
+test_that("the published manifest agrees with the in-package FG contract", {
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+  expect_identical(unlist(man$assets$fg_model.ubj$features), .FG_FEATURES)
+})

--- a/tests/testthat/test-fg_model_artifacts.R
+++ b/tests/testthat/test-fg_model_artifacts.R
@@ -84,3 +84,31 @@ test_that("the published manifest agrees with the in-package FG contract", {
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
   expect_identical(unlist(man$assets$fg_model.ubj$features), .FG_FEATURES)
 })
+
+test_that("every entry point forwards season to the era-aware FG model", {
+  # Regression guard. The v2 paths threaded `season` from the start, but the
+  # LEGACY paths called create_epa() without it, so with the era-aware model
+  # every FG/XP play aborted in .fg_make_prob() and the outer handler swallowed
+  # it -- the game came back with no modeled EPA at all. Validating only the v2
+  # paths is what let that through, so all four are exercised here.
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  fg <- load_fg_model()
+  skip_if(!inherits(fg, "xgb.Booster"), "bundled FG model unavailable")
+  skip_if(!any(startsWith(.booster_feature_names(fg), "era")),
+          "loaded FG model is not era-aware")
+
+  for (engine in c("legacy", "v2")) {
+    r <- try(suppressWarnings(suppressMessages(
+      espn_cfb_pbp(game_id = "401331242", epa_wpa = TRUE, engine = engine)
+    )), silent = TRUE)
+    skip_if(inherits(r, "try-error") || is.null(r) || !nrow(r),
+            paste("ESPN unavailable for engine", engine))
+    expect_true("fg_make_prob" %in% names(r),
+                info = paste("engine", engine))
+    # A game with no scored field goals would make this vacuous, so require at
+    # least one -- this game has several.
+    expect_gt(sum(!is.na(r$fg_make_prob)), 0)
+    expect_gt(sum(is.finite(r$EPA)), 100)
+  }
+})

--- a/tests/testthat/test-two_pt_artifacts.R
+++ b/tests/testthat/test-two_pt_artifacts.R
@@ -1,0 +1,119 @@
+### Gates for the two-point conversion probability (#140, model-scoring half).
+###
+### Two traps live in the state construction rather than the model:
+###   1. The PAT shares the touchdown's row, so pos_score_diff_start is the
+###      PRE-TD margin and must gain 6 -- but only on OFFENSIVE touchdowns,
+###      since pass_td also fires on pick-sixes.
+###   2. posteam_total is an implied TEAM total split out of the over/under by
+###      the spread, and CFBD's spread sign is the negation of the
+###      homeTeamSpread the formula is written against.
+
+test_that(".TWO_PT_FEATURES matches the bundle contract and uses ordinal era", {
+  expect_identical(.TWO_PT_FEATURES,
+                   c("posteam_spread", "posteam_total", "pos_score_diff", "era"))
+  # Ordinal era (2017 cut), like xpass -- not the FG model's one-hot set.
+  expect_equal(.cfb_era_ordinal(2018, 1), 3)
+})
+
+test_that(".cfb_posteam_total splits the over/under by the spread", {
+  # Home favoured by 7 (CFBD spread -7), total 50 -> home 28.5, away 21.5.
+  df <- data.frame(spread = c(-7, -7), over_under = c(50, 50),
+                   pos_team = c("H", "A"), home = c("H", "H"))
+  tot <- .cfb_posteam_total(df)
+  expect_equal(tot[1], 28.5)
+  expect_equal(tot[2], 21.5)
+  # The two implied totals must reconstruct the over/under.
+  expect_equal(tot[1] + tot[2], 50)
+  # And the favourite must carry the larger share.
+  expect_gt(tot[1], tot[2])
+})
+
+test_that(".cfb_posteam_total handles an away favourite", {
+  # CFBD spread +10 means the AWAY team is favoured.
+  df <- data.frame(spread = c(10, 10), over_under = c(60, 60),
+                   pos_team = c("H", "A"), home = c("H", "H"))
+  tot <- .cfb_posteam_total(df)
+  expect_equal(tot[1], 25)   # home underdog
+  expect_equal(tot[2], 35)   # away favourite
+  expect_equal(tot[1] + tot[2], 60)
+  expect_gt(tot[2], tot[1])
+})
+
+test_that(".cfb_posteam_total returns NULL without a line", {
+  expect_null(.cfb_posteam_total(data.frame(pos_team = "A", home = "A")))
+  expect_null(.cfb_posteam_total(data.frame(spread = NA_real_, over_under = NA_real_,
+                                            pos_team = "A", home = "A")))
+})
+
+test_that("the two-point score diff adds 6 on offensive touchdowns only", {
+  df <- data.frame(
+    pos_score_diff_start = c(-3, -3, -3, -3),
+    pass_td            = c(1, 0, 1, 0),
+    rush_td            = c(0, 1, 0, 0),
+    offense_score_play = c(1, 1, 0, 0)   # row 3 is a pick-six: pass_td but not offensive
+  )
+  expect_equal(.two_pt_score_diff(df), c(3, 3, -3, -3))
+})
+
+test_that("decision rows are offensive touchdowns only", {
+  df <- data.frame(
+    pass_td            = c(1, 0, 1, 0),
+    rush_td            = c(0, 1, 0, 0),
+    offense_score_play = c(1, 1, 0, 0)
+  )
+  expect_equal(.two_pt_decision_rows(df), c(TRUE, TRUE, FALSE, FALSE))
+})
+
+test_that(".pbp_add_two_pt_prob degrades to NA rather than raising", {
+  df <- data.frame(pos_score_diff_start = 0, pass_td = 1, rush_td = 0,
+                   offense_score_play = 1)
+  out <- .pbp_add_two_pt_prob(df, season = 2021)   # no spread/over_under
+  expect_true("prob_2pt" %in% names(out))
+  expect_true(is.na(out$prob_2pt))
+})
+
+test_that(".pbp_add_two_pt_prob needs a season for the era feature", {
+  df <- data.frame(pos_score_diff_start = 0, pass_td = 1, rush_td = 0,
+                   offense_score_play = 1, spread = -7, over_under = 50,
+                   pos_team = "H", home = "H")
+  expect_true(is.na(.pbp_add_two_pt_prob(df, season = NULL)$prob_2pt))
+})
+
+test_that(".pbp_add_two_pt_prob handles a zero-row frame", {
+  df <- data.frame(pos_score_diff_start = numeric(0))
+  out <- .pbp_add_two_pt_prob(df, season = 2021)
+  expect_equal(nrow(out), 0L)
+  expect_true("prob_2pt" %in% names(out))
+})
+
+test_that("the published manifest agrees with the two-point contract", {
+  skip_on_cran()
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+  expect_identical(unlist(man$assets$two_pt_model.ubj$features), .TWO_PT_FEATURES)
+})
+
+test_that("prob_2pt is a probability, on scoring rows only", {
+  skip_on_cran()
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  skip_if(is.null(.cfb_two_pt_model()), "bundled two_pt model unavailable")
+
+  df <- data.frame(
+    pos_score_diff_start = c(-8, -8, 0),
+    pass_td            = c(1, 0, 0),
+    rush_td            = c(0, 1, 0),
+    offense_score_play = c(1, 1, 0),     # third row is not a score
+    spread = -7, over_under = 55,
+    pos_team = "H", home = "H"
+  )
+  out <- .pbp_add_two_pt_prob(df, season = 2021)
+  expect_false(is.na(out$prob_2pt[1]))
+  expect_false(is.na(out$prob_2pt[2]))
+  expect_true(is.na(out$prob_2pt[3]))
+  p <- out$prob_2pt[1:2]
+  expect_true(all(p >= 0 & p <= 1))
+  # CFB two-point conversions succeed well under half the time.
+  expect_lt(max(p), 0.75)
+})

--- a/tests/testthat/test-wp_model_artifacts.R
+++ b/tests/testthat/test-wp_model_artifacts.R
@@ -78,6 +78,7 @@ test_that(".wp_feature_matrix refuses a frame missing model columns", {
 })
 
 test_that("the published manifest agrees with the in-package WP contract", {
+  skip_on_cran()
   skip_if_offline()
   man <- .cfb_model_manifest()
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
@@ -91,6 +92,7 @@ test_that("the published manifest agrees with the in-package WP contract", {
 })
 
 test_that(".wp_predict returns calibrated probabilities with sane ordering", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   wp_model <- load_wp_model()

--- a/tests/testthat/test-wp_model_artifacts.R
+++ b/tests/testthat/test-wp_model_artifacts.R
@@ -1,0 +1,118 @@
+### Gates for the shared `cfb_model_artifacts` WP model (issue #138 P2).
+###
+### WP has no class-order hazard (single probability out), so the risk here is
+### the FEATURE contract instead: twelve inputs in a fixed order, one of which
+### (`is_home`) cfbfastR does not carry and must derive. A silently wrong
+### is_home, or a column order drift, yields win probabilities that still look
+### like probabilities.
+
+test_that(".WP_NAIVE_FEATURES matches the bundle's declared contract", {
+  expect_length(.WP_NAIVE_FEATURES, 12L)
+  # Order is the booster's own; drift here scores the right numbers into the
+  # wrong slots without erroring.
+  expect_identical(.WP_NAIVE_FEATURES[1], "pos_team_receives_2H_kickoff")
+  expect_identical(.WP_NAIVE_FEATURES[12], "period")
+  expect_true("is_home" %in% .WP_NAIVE_FEATURES)
+  expect_false("spread_time" %in% .WP_NAIVE_FEATURES)  # that is wp_spread
+})
+
+test_that(".wp_is_home derives possession-is-home from team names", {
+  d <- data.frame(pos_team = c("Alabama", "Georgia", "Alabama"),
+                  home = c("Alabama", "Alabama", "Georgia"))
+  expect_equal(.wp_is_home(d), c(1, 0, 0))
+})
+
+test_that(".wp_is_home treats unresolved teams as not-home rather than NA", {
+  # The booster cannot take a missing value, and a neutral-site or unknown
+  # possession team must not fabricate home advantage.
+  d <- data.frame(pos_team = c(NA, "Ohio State"), home = c("Michigan", NA))
+  expect_equal(.wp_is_home(d), c(0, 0))
+  expect_false(anyNA(.wp_is_home(d)))
+})
+
+test_that(".wp_is_home prefers an existing is_home column", {
+  d <- data.frame(is_home = c(TRUE, FALSE), pos_team = "A", home = "B")
+  expect_equal(.wp_is_home(d), c(1, 0))
+})
+
+test_that(".wp_feature_matrix builds all twelve features in contract order", {
+  nd <- data.frame(
+    pos_team_receives_2H_kickoff = c(1, 0),
+    TimeSecsRem = c(1800, 300),
+    adj_TimeSecsRem = c(1800, 300),
+    ExpScoreDiff_Time_Ratio = c(0.001, -0.02),
+    pos_score_diff_start = c(0, -7),
+    down = factor(c(1, 3), levels = c("1", "2", "3", "4")),
+    distance = c(10, 8),
+    yards_to_goal = c(75, 40),
+    pos_team_timeouts_rem_before = c(3, 2),
+    def_pos_team_timeouts_rem_before = c(3, 1),
+    period = c(1, 4),
+    pos_team = c("Alabama", "Georgia"),
+    home = c("Alabama", "Alabama")
+  )
+  m <- .wp_feature_matrix(nd)
+  expect_identical(colnames(m), .WP_NAIVE_FEATURES)
+  expect_equal(nrow(m), 2L)
+  expect_equal(unname(m[, "is_home"]), c(1, 0))
+  expect_equal(unname(m[, "down"]), c(1, 3))   # VALUE, not factor code
+  expect_false(anyNA(m))
+})
+
+test_that(".wp_feature_matrix reads down values, not factor level codes", {
+  base <- data.frame(
+    pos_team_receives_2H_kickoff = 1, TimeSecsRem = 900, adj_TimeSecsRem = 900,
+    ExpScoreDiff_Time_Ratio = 0, pos_score_diff_start = 0,
+    distance = 10, yards_to_goal = 60, pos_team_timeouts_rem_before = 3,
+    def_pos_team_timeouts_rem_before = 3, period = 2, is_home = 1
+  )
+  a <- cbind(base, down = factor("1", levels = c("1", "2", "3", "4")))
+  b <- cbind(base, down = factor("1", levels = c("4", "3", "2", "1")))
+  expect_equal(.wp_feature_matrix(a)[, "down"], .wp_feature_matrix(b)[, "down"])
+  expect_equal(unname(.wp_feature_matrix(b)[, "down"]), 1)
+})
+
+test_that(".wp_feature_matrix refuses a frame missing model columns", {
+  nd <- data.frame(TimeSecsRem = 900, period = 1, is_home = 1)
+  expect_error(.wp_feature_matrix(nd), "adj_TimeSecsRem|missing")
+})
+
+test_that("the published manifest agrees with the in-package WP contract", {
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+  expect_identical(unlist(man$assets$wp_naive.ubj$features), .WP_NAIVE_FEATURES)
+  # wp_spread is the same contract plus spread_time in slot 2 -- pinned here so
+  # P2's spread work starts from a verified assumption.
+  spread <- unlist(man$assets$wp_spread.ubj$features)
+  expect_length(spread, 13L)
+  expect_identical(spread[2], "spread_time")
+  expect_identical(spread[-2], .WP_NAIVE_FEATURES)
+})
+
+test_that(".wp_predict returns calibrated probabilities with sane ordering", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  wp_model <- load_wp_model()
+  skip_if(!inherits(wp_model, "xgb.Booster"), "bundled WP model unavailable")
+
+  # Same game state, three score margins. WP must rise with the lead.
+  mk <- function(diff) data.frame(
+    pos_team_receives_2H_kickoff = 0, TimeSecsRem = 600, adj_TimeSecsRem = 600,
+    ExpScoreDiff_Time_Ratio = diff / 601, pos_score_diff_start = diff,
+    down = 1, distance = 10, yards_to_goal = 65,
+    pos_team_timeouts_rem_before = 3, def_pos_team_timeouts_rem_before = 3,
+    period = 4, is_home = 1
+  )
+  wp <- vapply(c(-14, 0, 14), function(d) .wp_predict(wp_model, mk(d)), numeric(1))
+
+  expect_length(wp, 3L)
+  expect_true(all(wp >= 0 & wp <= 1))
+  expect_true(all(diff(wp) > 0))   # monotone in score margin
+  expect_lt(wp[1], 0.5)            # down 14 late
+  expect_gt(wp[3], 0.5)            # up 14 late
+
+  # Batch equals row-by-row: guards against any reshape/recycling error.
+  batch <- .wp_predict(wp_model, do.call(rbind, lapply(c(-14, 0, 14), mk)))
+  expect_equal(batch, wp, tolerance = 1e-12)
+})

--- a/tests/testthat/test-wp_spread_artifacts.R
+++ b/tests/testthat/test-wp_spread_artifacts.R
@@ -1,0 +1,125 @@
+### Gates for the spread-aware WP model (`vegas_wp`, issue #138).
+###
+### The whole risk here is the SIGN. A flipped spread does not crash and does
+### not leave the [0,1] range -- it produces confident, exactly inverted win
+### probabilities. Two independent facts pin it, and both are asserted here:
+###   1. CFBD `spread` < 0 means the HOME team is favoured (verified over 83
+###      games of 2021 wk1 against `formatted_spread`, zero exceptions).
+###   2. The booster's WP rises monotonically with `spread_time`, i.e. positive
+###      means the team IN POSSESSION is favoured.
+
+test_that(".WP_SPREAD_FEATURES is wp_naive plus spread_time in slot 2", {
+  expect_length(.WP_SPREAD_FEATURES, 13L)
+  expect_identical(.WP_SPREAD_FEATURES[2], "spread_time")
+  expect_identical(.WP_SPREAD_FEATURES[-2], .WP_NAIVE_FEATURES)
+})
+
+test_that("pos_team_spread flips sign for the home team, keeps it for the away", {
+  # CFBD spread = +19.5 with the AWAY team favoured (the real 2021 Alabama at
+  # Miami line, formatted_spread "Alabama -19.5").
+  df <- data.frame(
+    spread   = c(19.5, 19.5),
+    pos_team = c("Alabama", "Miami"),   # away in possession, then home
+    home     = c("Miami", "Miami")
+  )
+  pts <- .wp_pos_team_spread(df)
+  expect_equal(pts[1], 19.5)    # favoured away team -> positive
+  expect_equal(pts[2], -19.5)   # underdog home team -> negative
+})
+
+test_that("pos_team_spread handles a home favourite (negative CFBD spread)", {
+  df <- data.frame(spread = c(-7, -7),
+                   pos_team = c("Georgia", "Auburn"),
+                   home = c("Georgia", "Georgia"))
+  pts <- .wp_pos_team_spread(df)
+  expect_equal(pts[1], 7)    # favoured home team -> positive
+  expect_equal(pts[2], -7)   # underdog away team -> negative
+})
+
+test_that(".wp_pos_team_spread returns NULL when there is no usable line", {
+  expect_null(.wp_pos_team_spread(data.frame(pos_team = "A", home = "A")))
+  expect_null(.wp_pos_team_spread(
+    data.frame(spread = NA_real_, pos_team = "A", home = "A")))
+})
+
+test_that("spread_time decays the line toward zero as the game elapses", {
+  df <- data.frame(spread = c(-14, -14, -14),
+                   pos_team = "A", home = "A",
+                   adj_TimeSecsRem = c(3600, 1800, 0))
+  st <- .wp_spread_time(df)
+  expect_equal(st[1], 14)                    # kickoff: undecayed
+  expect_true(abs(st[2]) < abs(st[1]))       # halfway: decayed
+  expect_true(abs(st[3]) < abs(st[2]))       # final gun: decayed further
+  expect_true(all(sign(st) == 1))            # decay never flips the sign
+  expect_equal(st[3], 14 * exp(-4))
+})
+
+test_that("spread_time clamps elapsed share at zero", {
+  # An overtime clock can exceed regulation; the share must not go negative and
+  # amplify the line instead of decaying it.
+  df <- data.frame(spread = -10, pos_team = "A", home = "A",
+                   adj_TimeSecsRem = 4200)
+  expect_equal(.wp_spread_time(df), 10)
+})
+
+test_that(".pbp_add_vegas_wp adds an NA column rather than raising", {
+  df <- data.frame(down = 1, distance = 10)   # no spread, no inputs
+  out <- .pbp_add_vegas_wp(df)
+  expect_true("vegas_wp" %in% names(out))
+  expect_true(is.na(out$vegas_wp))
+})
+
+test_that(".pbp_add_vegas_wp handles a zero-row frame", {
+  out <- .pbp_add_vegas_wp(data.frame(spread = numeric(0)))
+  expect_equal(nrow(out), 0L)
+  expect_true("vegas_wp" %in% names(out))
+})
+
+test_that("the published manifest agrees with the in-package spread contract", {
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+  expect_identical(unlist(man$assets$wp_spread.ubj$features), .WP_SPREAD_FEATURES)
+})
+
+test_that("vegas_wp favours the favourite -- the sign gate", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  skip_if(is.null(.cfb_wp_spread_model()), "bundled wp_spread model unavailable")
+
+  # Kickoff of a tied game, ball with the AWAY team, who are 19.5-point
+  # favourites (CFBD spread = +19.5). A flipped sign gives ~0.10 instead.
+  base <- data.frame(
+    pos_team_receives_2H_kickoff = 0, TimeSecsRem = 3600,
+    adj_TimeSecsRem = 3600, ExpScoreDiff_Time_Ratio = 0,
+    pos_score_diff_start = 0, down = 1, distance = 10, yards_to_goal = 75,
+    pos_team_timeouts_rem_before = 3, def_pos_team_timeouts_rem_before = 3,
+    period = 1, spread = 19.5, pos_team = "Alabama", home = "Miami"
+  )
+  fav <- .pbp_add_vegas_wp(base)$vegas_wp
+  expect_gt(fav, 0.75)
+
+  # Same game, ball with the home underdog: mirror image, well under 0.5.
+  dog <- base; dog$pos_team <- "Miami"
+  dog_wp <- .pbp_add_vegas_wp(dog)$vegas_wp
+  expect_lt(dog_wp, 0.25)
+  expect_gt(fav, dog_wp)
+})
+
+test_that("vegas_wp rises monotonically with the size of the line", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  skip_if(is.null(.cfb_wp_spread_model()), "bundled wp_spread model unavailable")
+
+  mk <- function(spread) data.frame(
+    pos_team_receives_2H_kickoff = 0, TimeSecsRem = 3600,
+    adj_TimeSecsRem = 3600, ExpScoreDiff_Time_Ratio = 0,
+    pos_score_diff_start = 0, down = 1, distance = 10, yards_to_goal = 75,
+    pos_team_timeouts_rem_before = 3, def_pos_team_timeouts_rem_before = 3,
+    period = 1, spread = spread, pos_team = "A", home = "B"  # away possession
+  )
+  wp <- vapply(c(-21, -7, 0, 7, 21),
+               function(s) .pbp_add_vegas_wp(mk(s))$vegas_wp, numeric(1))
+  expect_true(all(wp >= 0 & wp <= 1))
+  expect_true(all(diff(wp) > 0))
+})

--- a/tests/testthat/test-wp_spread_artifacts.R
+++ b/tests/testthat/test-wp_spread_artifacts.R
@@ -76,6 +76,7 @@ test_that(".pbp_add_vegas_wp handles a zero-row frame", {
 })
 
 test_that("the published manifest agrees with the in-package spread contract", {
+  skip_on_cran()
   skip_if_offline()
   man <- .cfb_model_manifest()
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
@@ -83,6 +84,7 @@ test_that("the published manifest agrees with the in-package spread contract", {
 })
 
 test_that("vegas_wp favours the favourite -- the sign gate", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   skip_if(is.null(.cfb_wp_spread_model()), "bundled wp_spread model unavailable")
@@ -107,6 +109,7 @@ test_that("vegas_wp favours the favourite -- the sign gate", {
 })
 
 test_that("vegas_wp rises monotonically with the size of the line", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   skip_if(is.null(.cfb_wp_spread_model()), "bundled wp_spread model unavailable")

--- a/tests/testthat/test-wpa_overlay.R
+++ b/tests/testthat/test-wpa_overlay.R
@@ -1,0 +1,72 @@
+### Gates for .wpa_overlay(), the shared WPA differencing (#138).
+###
+### The naive WPA block in .pbp_wpa_calcs_naive() is left INLINE and untouched
+### because it produces published values. .wpa_overlay() is the extracted
+### equivalent that vegas_wpa uses. The first test is what makes that split
+### safe: it asserts the helper reproduces the inline result exactly, so the
+### two cannot drift into disagreeing about turnovers or half ends.
+
+mk_game <- function() {
+  # A small but adversarial game: a possession change, a half end with a
+  # trailing timeout, and an end-of-period marker -- the three branches the
+  # overlays exist for.
+  data.frame(
+    pos_team = c("A", "A", "B", "B", "A", "A"),
+    lead_pos_team = c("A", "B", "B", "A", "A", NA),
+    lead_pos_team2 = c("B", "B", "A", "A", NA, NA),
+    home = "A",
+    play_type = c("Rush", "Pass", "Rush", "Timeout", "Pass", "End Period"),
+    lead_play_type = c("Pass", "Rush", "Timeout", "Pass", "End Period", NA),
+    end_of_half = c(0, 0, 0, 1, 0, 0),
+    change_of_pos_team = c(0, 1, 0, 1, 0, 0),
+    pos_team_receives_2H_kickoff = c(0, 0, 0, 0, 1, 1),
+    wp_before = c(0.50, 0.55, 0.40, 0.42, 0.61, 0.65),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that(".wpa_overlay reproduces the inline naive WPA exactly", {
+  df <- mk_game()
+  inline <- .pbp_wpa_calcs_naive(df)$wpa
+  helper <- round(.wpa_overlay(df, df$wp_before), 7)
+  expect_equal(helper, inline)
+})
+
+test_that(".wpa_overlay flips perspective on a possession change", {
+  df <- mk_game()
+  w <- .wpa_overlay(df, df$wp_before)
+  # Row 2 hands the ball to B (pos_team A, lead_pos_team B), so the next WP is
+  # B's: A's change is (1 - 0.40) - 0.55, not 0.40 - 0.55.
+  expect_equal(w[2], (1 - 0.40) - 0.55)
+  # Row 1 keeps possession, so it is a plain difference.
+  expect_equal(w[1], 0.55 - 0.50)
+})
+
+test_that(".wpa_overlay is driven by the column it is handed", {
+  df <- mk_game()
+  # Same frame, different WP column -> different WPA. If the helper secretly
+  # read wp_before instead of its argument, these would be identical.
+  alt <- df$wp_before * 0.5 + 0.25
+  expect_false(isTRUE(all.equal(.wpa_overlay(df, alt),
+                                .wpa_overlay(df, df$wp_before))))
+})
+
+test_that("vegas_wpa is derived when vegas_wp is present, and skipped when not", {
+  df <- mk_game()
+  expect_false("vegas_wpa" %in% names(.pbp_wpa_calcs_naive(df)))
+
+  df$vegas_wp <- c(0.70, 0.74, 0.22, 0.25, 0.80, 0.83)
+  out <- .pbp_wpa_calcs_naive(df)
+  expect_true(all(c("vegas_wpa", "vegas_wp_after") %in% names(out)))
+  expect_equal(out$vegas_wpa, round(.wpa_overlay(df, df$vegas_wp), 7))
+  expect_equal(out$vegas_wp_after, round(df$vegas_wp + out$vegas_wpa, 7))
+  # The naive columns must be unaffected by vegas_wp being present.
+  expect_equal(out$wpa, .pbp_wpa_calcs_naive(mk_game())$wpa)
+})
+
+test_that("an all-NA vegas_wp yields an all-NA vegas_wpa, not an error", {
+  df <- mk_game()
+  df$vegas_wp <- NA_real_
+  out <- .pbp_wpa_calcs_naive(df)
+  expect_true(all(is.na(out$vegas_wpa)))
+})

--- a/tests/testthat/test-xpass_model_artifacts.R
+++ b/tests/testthat/test-xpass_model_artifacts.R
@@ -59,6 +59,7 @@ test_that(".pbp_add_xpass handles a zero-row frame", {
 })
 
 test_that("the published manifest agrees with the in-package xpass contract", {
+  skip_on_cran()
   skip_if_offline()
   man <- .cfb_model_manifest()
   skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
@@ -66,6 +67,7 @@ test_that("the published manifest agrees with the in-package xpass contract", {
 })
 
 test_that("xpass is scrimmage-only and rises on obvious passing downs", {
+  skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("xgboost")
   skip_if(is.null(.cfb_xpass_model()), "bundled xpass model unavailable")

--- a/tests/testthat/test-xpass_model_artifacts.R
+++ b/tests/testthat/test-xpass_model_artifacts.R
@@ -1,0 +1,98 @@
+### Gates for the bundled expected-pass model (`xpass` / `pass_oe`, #138).
+###
+### Two traps, both shared with models already in this PR:
+###   * `pos_score_diff` is sourced from `pos_score_diff_start`, not the frame's
+###     like-named column, which holds a different value.
+###   * the ORDINAL era here cuts at 2006/2013/2017, NOT the one-hot era0..era3
+###     cuts of 2006/2013/2020 used by the FG model.
+
+test_that(".XPASS_FEATURES matches the bundle contract", {
+  expect_identical(
+    .XPASS_FEATURES,
+    c("down", "distance", "yards_to_goal", "pos_score_diff",
+      "TimeSecsRem", "era", "period")
+  )
+})
+
+test_that("the ordinal era is NOT the one-hot era set", {
+  expect_identical(.XPASS_ERA_CUTS, c(2006, 2013, 2017))
+  expect_false(identical(.XPASS_ERA_CUTS, .FG_ERA_CUTS))
+  # 2018-2020 is exactly where the two disagree: ordinal era 3, one-hot era2.
+  expect_equal(.cfb_era_ordinal(2018, 1), 3)
+  expect_equal(unname(.cfb_era_onehot(2018, 1)[1, ]), c(0, 0, 1, 0))
+})
+
+test_that(".cfb_era_ordinal maps every boundary", {
+  s <- c(2000, 2006, 2007, 2013, 2014, 2017, 2018, 2025)
+  expect_equal(.cfb_era_ordinal(s, length(s)), c(0, 0, 1, 1, 2, 2, 3, 3))
+})
+
+test_that(".cfb_era_ordinal recycles a scalar season", {
+  expect_equal(.cfb_era_ordinal(2021, 3), c(3, 3, 3))
+})
+
+test_that(".pbp_add_xpass degrades to NA rather than raising", {
+  df <- data.frame(down = 1, distance = 10)
+  out <- .pbp_add_xpass(df, season = 2021)
+  expect_true(all(c("xpass", "pass_oe") %in% names(out)))
+  expect_true(is.na(out$xpass))
+})
+
+test_that(".pbp_add_xpass refuses to invent an era when season is absent", {
+  # Without a season the ordinal era would silently default, shifting every
+  # expected-pass rate -- emit NA instead.
+  df <- data.frame(down = 1, distance = 10, yards_to_goal = 60,
+                   pos_score_diff_start = 0, TimeSecsRem = 900, period = 2,
+                   pass = 1, rush = 0)
+  expect_true(is.na(.pbp_add_xpass(df, season = NULL)$xpass))
+  expect_true(is.na(.pbp_add_xpass(df, season = NA)$xpass))
+})
+
+test_that(".pbp_add_xpass handles a zero-row frame", {
+  df <- data.frame(down = numeric(0), distance = numeric(0),
+                   yards_to_goal = numeric(0), pos_score_diff_start = numeric(0),
+                   TimeSecsRem = numeric(0), period = numeric(0),
+                   pass = numeric(0), rush = numeric(0))
+  out <- .pbp_add_xpass(df, season = 2021)
+  expect_equal(nrow(out), 0L)
+  expect_true(all(c("xpass", "pass_oe") %in% names(out)))
+})
+
+test_that("the published manifest agrees with the in-package xpass contract", {
+  skip_if_offline()
+  man <- .cfb_model_manifest()
+  skip_if(is.null(man), "cfb_model_artifacts MANIFEST.json unavailable")
+  expect_identical(unlist(man$assets$xpass_model.ubj$features), .XPASS_FEATURES)
+})
+
+test_that("xpass is scrimmage-only and rises on obvious passing downs", {
+  skip_if_offline()
+  skip_if_not_installed("xgboost")
+  skip_if(is.null(.cfb_xpass_model()), "bundled xpass model unavailable")
+
+  df <- data.frame(
+    down = c(3, 1, 3),
+    distance = c(15, 10, 15),
+    yards_to_goal = c(60, 60, 60),
+    pos_score_diff_start = c(0, 0, 0),
+    TimeSecsRem = c(1800, 1800, 1800),
+    period = c(2, 2, 2),
+    pass = c(1, 0, 0),
+    rush = c(0, 1, 0)      # third row is neither -- a punt/kick
+  )
+  out <- .pbp_add_xpass(df, season = 2021)
+
+  expect_false(is.na(out$xpass[1]))
+  expect_false(is.na(out$xpass[2]))
+  expect_true(is.na(out$xpass[3]))          # non-scrimmage -> no xpass
+  expect_true(all(out$xpass[1:2] >= 0 & out$xpass[1:2] <= 1))
+  # 3rd & 15 must be a likelier pass than 1st & 10.
+  expect_gt(out$xpass[1], out$xpass[2])
+  expect_gt(out$xpass[1], 0.7)
+
+  # pass_oe is percentage points: passing when expected to pass scores lower
+  # than passing when nobody expects it.
+  expect_equal(out$pass_oe[1], 100 * (1 - out$xpass[1]))
+  expect_equal(out$pass_oe[2], 100 * (0 - out$xpass[2]))
+  expect_lt(out$pass_oe[2], 0)              # ran the ball -> negative
+})


### PR DESCRIPTION
P1 of #138. Replaces the `nnet::multinom` EP model with the XGBoost artifact from the [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts) release — **the same artifact `sportsdataverse-py` scores with**, so both libraries agree on EPA for a play and a retrain updates both from one publish.

## Fixes #5

`epa_wpa = TRUE` no longer aborts with `predict.nnet(): missing values in 'x'` on mid-era CFBD data. Verified against the exact calls that failed 40/40 in the 2026-08-26 benchmark grid:

| season wk1 | legacy engine | v2 engine |
|---|---|---|
| 2006 | ✅ 9,922 rows, EPA finite 96.1% | ✅ 96.1% |
| 2008 | ✅ 12,005 rows, 96.1% | ✅ 96.1% |
| 2011 | ✅ 13,962 rows, 95.8% | ✅ 95.8% |
| 2013 | ✅ 13,800 rows, 95.9% | ✅ 95.9% |
| 2021 (control) | ✅ 96.8% | ✅ 96.8% |

ESPN path spot-checked across eras too (2006 / 2013 wk1 / 2013 CCG / 2021 natty) — all produce finite EPA.

## One helper, eight call sites

Every `predict(ep_model, ...)` in `create_epa.R` and `pbp_create_epa.R` now routes through `.ep_predict()`, which returns the seven next-score probabilities **already named and ordered by `.EP_LEV`**. Downstream column names (`TD_before`, `Opp_FG_after`, …) and the positional `weights <- c(0, 3, -3, -2, -7, 2, 7)` vector are untouched, so no other pipeline code moved. It accepts either model generation, so a cached legacy artifact still works.

## ⚠️ The class-order trap, and how it's handled

The bundle's class order and the retired `ep_model$lev` **share no fixed point**. On 1st & 10 at own 25 the correct EP is **0.6635**; applying cfbfastR's weights to the bundle's raw output gives **0.2622** — wrong, but comfortably inside a plausible range, so it would survive a range check or an eyeball.

The permutation is therefore read from the bundle's `MANIFEST.json` (`ep_class_contract`) rather than inlined, with an in-package fallback for offline use that a test asserts equals the published value. A dedicated test also demonstrates the naive mapping produces a *different* number, so the trap can't silently reopen.

## Other correctness fixes found along the way

- **missed-FG hypothetical now sets `distance = 10`.** It previously set only `log_ydstogo = log(10)` (what the retired formula read) and left the *real* play's `distance`, which the new model reads — it would have quietly contradicted the "1st & 10 after a miss" premise.
- **`.ep_feature_matrix()` reads down VALUES, not factor level codes.** `as.numeric()` on a factor returns codes, so a frame with reordered levels would have turned 1st down into 4th down. Covered by a test.
- The old single-row `t()` transpose special case is gone — the helper always returns an n × 7 frame.

## Caching / deps

Artifacts cache under the package cache dir and refresh on the `cfbfastR.cache_duration` TTL (default 24h), so a republished model is picked up **without a package update** — that TTL is what makes "publish once, both libraries follow" true. A stale cached copy is still used if the release is unreachable. `xgboost` floor moves to `>= 1.7` for `.ubj` support and **stays in Suggests** (EPA is opt-in via `epa_wpa=TRUE`); without it, or offline with no cache, the retired `nnet` model loads as fallback.

## Tests

- New `test-ep_model_artifacts.R`: 26 assertions, 0 skips locally — feature-contract construction, down-encoding robustness, manifest↔fallback agreement, batch-vs-row-by-row equality (catches a `byrow` reshape error that would scramble plays), probability sums, football sanity (3rd & 2 at the 5 → EP 4.81; 4th & 10 from own 5 down 14 → −0.64), and the wrong-permutation demonstration.
- Existing suites green: **2003 passing, 0 failures** across `pbp_equivalence`, all `parity_*` sdv-py oracles, and boxscore parity.

## Heads-up

**Published EPA/WPA values will change** — this is a different model generation (nnet EP 0.8332 vs bundle 0.6635 on the same state; class-probability shapes are close, so expect high correlation but shifted values). Datasets should be rebuilt wholesale rather than mixing old and new. WP is untouched here and still the `mgcv::bam` GAM; that's P2.

## Summary by Sourcery

Adopt the shared model-artifact bundle for consistent EPA/WPA scoring and add completion, spread-aware win probability, expected pass rate, and two-point probability outputs.

New Features:
- Add completion probability and completion over expected metrics for pass plays.
- Add spread-aware win probability with corresponding WPA metrics.
- Add expected pass rate and pass over expected metrics on scrimmage plays.
- Add two-point conversion probability scoring for offensive touchdowns.

Bug Fixes:
- Replace the legacy EP scoring path to prevent missing-value failures on mid-era play-by-play data.
- Correct EP class ordering, feature encoding, and missed-field-goal hypothetical state construction.

Enhancements:
- Use shared XGBoost EP, WP, and FG artifacts compatible with sportsdataverse-py while retaining legacy model fallbacks.
- Cache and refresh shared model artifacts using a configurable TTL with stale-cache support.
- Centralize model feature construction and prediction across legacy and modular EPA/WPA pipelines.
- Thread season information through EPA scoring for era-aware field-goal and auxiliary models.
- Share WPA overlay logic for naive and spread-aware win probability outputs.

Build:
- Raise the xgboost Suggests minimum version to support bundled UBJ model artifacts.

Documentation:
- Document the shared model artifacts, new scoring outputs, caching behavior, fallback behavior, and changed EPA/WPA values in NEWS and generated documentation.

Tests:
- Add model-contract, feature-encoding, class-order, probability sanity, fallback, season handling, and WPA overlay tests for the new artifact-backed scoring paths.

Chores:
- Update ESPN and CFBD pipelines to pass season metadata and run the expanded model-scoring stages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added completion probability (CP), CPOE, spread-aware win probability (`vegas_wp`), expected pass rate (`xpass`), and pass over expected (`pass_oe`) outputs.
  * Added era-aware modeling using shared, cached model artifacts.
  * Added optional season-aware field-goal modeling.
* **Bug Fixes**
  * Fixed EPA/WPA failures on certain mid-era data.
  * Standardized Expected Points probability ordering for reliable scoring.
* **Compatibility**
  * Existing EPA and WPA values may change with the updated models.
  * Requires `xgboost` 1.7 or later; an offline legacy fallback remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->