### PR TITLE
fix(pbp): fourth-down return-TD clamp direction, and make the fail-clamp gate fire

### DIFF
--- a/R/pbp_fourth_down.R
+++ b/R/pbp_fourth_down.R
@@ -277,8 +277,14 @@ NULL
 #' The rare return-touchdown rows (`yards_to_goal_end == 100`, carrying under
 #' 0.2% of the mass) hand the ball straight back: everything the flip swapped is
 #' swapped again so the punting team is the one receiving a kickoff, and the
-#' seven points come off its differential. The clamp is applied to those rows
-#' exactly as cfb4th applies it, even though possession did not change there.
+#' seven points come off its differential.
+#'
+#' Because possession did NOT change on those rows, the win probability there is
+#' already the punting team's, and the kneel-out is a WIN for it rather than a
+#' loss. cfb4th clamps every row to zero, which pins a punting team that still
+#' leads after conceding the score to a certain loss. That is a deliberate
+#' divergence rather than a faithful port -- the same rule pointed at the wrong
+#' team is what this whole surface had wrong in three other places.
 #'
 #' @return Numeric, `nrow(st)` long; `NA` where the play's field position has no
 #'   punt distribution (inside the 31) or the table is unavailable.
@@ -323,8 +329,15 @@ NULL
   # cfb4th reads the clamp off the RESULTING frame: the team now holding the
   # ball leads, and the team it just took the ball from is out of timeouts, so
   # whoever is asking loses.
-  wp <- .fd_kneel_clamp(wp, s$pos_score_diff_start > 0, s$adj_TimeSecsRem,
-                        s$def_pos_team_timeouts_rem_before, 0, period = s$period)
+  # Pin to 0 where the ball actually changed hands, and to 1 on the return-TD
+  # rows where it came straight back -- see the note above.
+  wp <- ifelse(
+    !rtd,
+    .fd_kneel_clamp(wp, s$pos_score_diff_start > 0, s$adj_TimeSecsRem,
+                    s$def_pos_team_timeouts_rem_before, 0, period = s$period),
+    .fd_kneel_clamp(wp, s$pos_score_diff_start > 0, s$adj_TimeSecsRem,
+                    s$def_pos_team_timeouts_rem_before, 1, period = s$period)
+  )
 
   agg <- tapply(long$pct * wp, idx, sum)
   out[as.integer(names(agg))] <- as.numeric(agg)

--- a/tests/testthat/test-fourth-down.R
+++ b/tests/testthat/test-fourth-down.R
@@ -207,10 +207,18 @@ test_that("turning it over on downs while LEADING is not an automatic loss", {
   # The clamp condition is read off the post-turnover frame, where the score
   # differential has already been negated. Reading it as "the offence trails"
   # inverts it and pins a LEADING team's failed-conversion WP to zero.
-  lead <- .fd_go_wp(mk_late(distance = 1, diff = 3, pos_to = 3, def_to = 0))
-  trail <- .fd_go_wp(mk_late(distance = 1, diff = -3, pos_to = 3, def_to = 0))
+  #
+  # The timeouts here are load-bearing and easy to get backwards. After a
+  # turnover `new_def_to` is the OFFENCE'S pre-play count, so firing the clamp
+  # needs `pos_to = 0` -- not `def_to = 0`, which leaves `new_def_to == 3` and
+  # no threshold applies at all. Configured that way this test passes on the
+  # model's own gradient with EITHER sign (0.776 vs 0.037), which is no gate.
+  lead <- .fd_go_wp(mk_late(distance = 1, diff = 3, pos_to = 0, def_to = 3))
+  trail <- .fd_go_wp(mk_late(distance = 1, diff = -3, pos_to = 0, def_to = 3))
+  # Exactly zero is the clamp's signature -- the model alone never returns it.
+  expect_identical(trail$wp_fail, 0)
+  # And the leading team must be left alone entirely.
   expect_gt(lead$wp_fail, 0.5)
-  expect_lt(trail$wp_fail, 0.1)
 })
 
 test_that("field-goal probability carries cfb4th's two policy clamps", {

--- a/tests/testthat/test-fourth-down.R
+++ b/tests/testthat/test-fourth-down.R
@@ -324,3 +324,19 @@ test_that("a goal-line gain is a touchdown even when distance exceeds it", {
   # when every outcome is bucketed as a failure.
   expect_gt(bad$wp_succeed, bad$wp_fail)
 })
+
+test_that("a punt return touchdown clamps toward a win, not a loss", {
+  # Possession never changes on those rows -- the ball comes straight back --
+  # so the win probability there is already the punting team's and a kneel-out
+  # is a WIN for it. cfb4th clamps every row to zero, which pins a punting team
+  # still leading after conceding the score to a certain loss.
+  #
+  # Asserted through the clamp helper: return-TD rows carry under 0.2% of the
+  # punt distribution's mass, so an assertion on punt_wp would pass either way.
+  wp <- 0.5
+  lead <- TRUE
+  expect_equal(.fd_kneel_clamp(wp, lead, 60, 0, 0, period = 4), 0)
+  expect_equal(.fd_kneel_clamp(wp, lead, 60, 0, 1, period = 4), 1)
+  # Not leading is nobody's kneel-out, whichever value is passed.
+  expect_equal(.fd_kneel_clamp(wp, FALSE, 60, 0, 1, period = 4), 0.5)
+})

--- a/tests/testthat/test-fourth-down.R
+++ b/tests/testthat/test-fourth-down.R
@@ -340,3 +340,29 @@ test_that("a punt return touchdown clamps toward a win, not a loss", {
   # Not leading is nobody's kneel-out, whichever value is passed.
   expect_equal(.fd_kneel_clamp(wp, FALSE, 60, 0, 1, period = 4), 0.5)
 })
+
+test_that(".fd_punt_wp itself routes return touchdowns to the winning clamp", {
+  skip_on_cran(); skip_if_offline(); skip_if_not_installed("xgboost")
+  skip_if(is.null(.cfb_wp_spread_model()), "wp_spread unavailable")
+  # The helper-level test above pins the clamp's arithmetic but never runs the
+  # `rtd` selector, so a regression to `value = 0` inside .fd_punt_wp() would
+  # not fail it. Swap the empirical distribution for a certain return
+  # touchdown: punt_wp is then determined entirely by that branch, and the
+  # 0.2%-of-the-mass problem that forced the helper-level test disappears.
+  old <- .cfb_model_env$punt_dist
+  on.exit(.cfb_model_env$punt_dist <- old, add = TRUE)
+  .cfb_model_env$punt_dist <- data.frame(
+    yards_to_goal = 50, yards_to_goal_end = 100, pct = 1
+  )
+
+  # Up 10, concede the return TD -> still up 3, and the receiving team has no
+  # timeouts left to stop the clock, so the punting team kneels out a win.
+  lead <- .fd_punt_wp(mk_late(distance = 10, yards_to_goal = 50, diff = 10,
+                              pos_to = 3, def_to = 0))
+  expect_identical(lead, 1)
+
+  # Up only 3, the same return TD puts them behind, so nothing is clamped.
+  behind <- .fd_punt_wp(mk_late(distance = 10, yards_to_goal = 50, diff = 3,
+                                pos_to = 3, def_to = 0))
+  expect_lt(behind, 1)
+})


### PR DESCRIPTION
Two fixes to the fourth-down surface that landed in #142, both found while fixing the same code upstream in sportsdataverse/sportsdataverse-py#398.

## 1. The fail-clamp gate never fired (test-only)

The test added in #142 asserted the right thing but never exercised the clamp, so it would have passed with the sign either way.

After a turnover, `new_def_to` is the **offence's** pre-play timeout count — so firing the clamp needs `pos_to = 0`. The test used `def_to = 0`, which leaves `new_def_to == 3` and none of the three thresholds applies. Both branches were reading the model's own gradient:

| config | leading by 3 | trailing by 3 |
|---|---|---|
| as merged (`pos_to = 3, def_to = 0`) | 0.7758 | 0.0366 |
| clamp can fire (`pos_to = 0, def_to = 3`) | 0.7249 | **0** |

The model alone never returns exactly 0, so that is the clamp's signature, and the assertion is now `expect_identical(trail$wp_fail, 0)`.

**Verified by mutation**: flipping `pos_diff > 0` back to the inverted `< 0` fails this file (2 assertions, `lead$wp_fail` reading 0.00). Before the change the same mutation passed.

## 2. Punt return-touchdown rows clamped the wrong way (behaviour)

When #142 landed I noticed this and deliberately kept cfb4th's behaviour, on the grounds that return-TD rows carry under 0.2% of the distribution's mass. That was the wrong call, and a reviewer on the Python side made the case better than I had made it to myself.

Possession never changes on those rows — the ball comes straight back and the punting team receives the kickoff — so the win probability there is already that team's, and a kneel-out is a **win** for it. Clamping to zero pins a punting team that still leads after conceding the score to a certain loss.

#142 fixed three inversions that all reduce to *the kneel-out rule pointed at the wrong team*. Leaving a fourth instance in place because the reference implementation shares it is not faithfulness; it is a smaller copy of the same bug. Documented on the function as a deliberate divergence from cfb4th.

Gated through `.fd_kneel_clamp()` directly rather than through `punt_wp` — at 0.2% of the mass an aggregate assertion passes with the sign either way, which is exactly the trap that made the fail-clamp test in fix 1 inert.

## Gates

`tests/testthat/test-fourth-down.R` 64 passing; `R CMD check` 0 errors, 0 warnings (the NOTE is the known worktree `.git`-is-a-file artifact).

Keeps cfbfastR aligned with sportsdataverse/sportsdataverse-py#398, which makes the same two changes.

## Summary by Sourcery

Correct fourth-down kneel-out clamping and strengthen tests for turnover and punt return-touchdown outcomes.

Bug Fixes:
- Correct fourth-down failure clamping so the gate fires for teams that are trailing after a turnover.
- Clamp punt return-touchdown outcomes toward a win for the punting team when possession returns to it.

Enhancements:
- Document the intentional divergence from cfb4th for punt return-touchdown kneel-out handling.

Tests:
- Fix the fourth-down clamp test setup and assert the exact zero clamp signature.
- Add coverage for return-touchdown clamp direction at both the helper and punt-probability levels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected win-probability handling for punt-return touchdowns, ensuring the returning team is treated as likely to win rather than lose.
  * Improved fourth-down and kneeling scenarios so leading teams are correctly clamped toward a win.
* **Tests**
  * Added coverage for punt-return touchdowns and strengthened validation of turnover-on-downs scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->