### PR TITLE
test(pbp): lock the pre-2014 standalone-PAT row out of the two-point decision

### DIFF
--- a/tests/testthat/test-two_pt_artifacts.R
+++ b/tests/testthat/test-two_pt_artifacts.R
@@ -88,13 +88,35 @@ test_that("a standalone PAT row is never a decision row (pre-2014 shape)", {
   expect_equal(.two_pt_decision_rows(df), c(FALSE, FALSE, FALSE, TRUE))
 })
 
-test_that("the TD flags that gate the decision exclude PAT play types", {
-  # Locks the derivation the test above depends on: these play_type values must
-  # not be treated as touchdowns by the exact-match rule in clean_pbp_dat().
+test_that("the production TD derivation classifies no PAT play type as a touchdown", {
+  # The test above holds only because clean_pbp_dat() assigns pass_td/rush_td from
+  # an EXACT play_type match. Comparing PAT literals against touchdown literals
+  # here would be tautological -- it would pass no matter what production does.
+  # So read the rule out of the SHIPPED function and evaluate PAT types against it:
+  # broaden the rule (another play_type, or a switch to a regex) and this fails.
+  src <- paste(deparse(body(cfbfastR:::.pbp_clean_pbp_dat)), collapse = " ")
+
+  td_set <- function(flag) {
+    i <- regexpr(paste0(flag, " = ifelse"), src, fixed = TRUE)
+    expect_true(i > 0,
+                info = paste0("no ", flag, " assignment found; if it was restructured",
+                              " this guard must be UPDATED, not deleted"))
+    rest <- substring(src, i)
+    j <- regexpr("%in% ", rest, fixed = TRUE)
+    rest <- substring(rest, j + 5L)
+    eval(parse(text = substring(rest, 1L, regexpr(")", rest, fixed = TRUE))))
+  }
+
   pat_types <- c("Extra Point Good", "Extra Point Missed",
                  "Two-Point Conversion Good", "Two-Point Conversion Missed")
-  expect_false(any(pat_types %in% c("Passing Touchdown")))
-  expect_false(any(pat_types %in% c("Rushing Touchdown")))
+  for (flag in c("pass_td", "rush_td")) {
+    s <- td_set(flag)
+    expect_gt(length(s), 0)
+    expect_false(any(pat_types %in% s),
+                 info = paste(flag, "now treats a PAT play type as a touchdown;",
+                              "the +6 in .two_pt_score_diff() would fire on an",
+                              "already-post-TD row"))
+  }
 })
 
 test_that(".pbp_add_two_pt_prob degrades to NA rather than raising", {

--- a/tests/testthat/test-two_pt_artifacts.R
+++ b/tests/testthat/test-two_pt_artifacts.R
@@ -64,6 +64,39 @@ test_that("decision rows are offensive touchdowns only", {
   expect_equal(.two_pt_decision_rows(df), c(TRUE, TRUE, FALSE, FALSE))
 })
 
+test_that("a standalone PAT row is never a decision row (pre-2014 shape)", {
+  # Before 2014 the extra point / two-point try is its OWN row rather than
+  # sharing the touchdown's. Those rows are already POST-touchdown, so the +6 in
+  # .two_pt_score_diff() must never reach them -- it would score the decision six
+  # points further ahead than the game actually was.
+  #
+  # Today that holds only BY CONSTRUCTION: pass_td/rush_td are assigned from an
+  # exact play_type match ("Passing Touchdown" / "Rushing Touchdown") in
+  # clean_pbp_dat(), so a standalone PAT scores 0 on both and cannot qualify.
+  # Nothing else enforces it. Broaden that assignment -- a regex, or folding in
+  # "Two-Point Conversion Good" -- and the +6 silently starts firing on already-
+  # post-TD rows. This is the test that would notice.
+  df <- data.frame(
+    play_type          = c("Extra Point Good", "Two-Point Conversion Good",
+                           "Extra Point Missed", "Passing Touchdown"),
+    pass_td            = c(0, 0, 0, 1),
+    rush_td            = c(0, 0, 0, 0),
+    # a PAT IS an offensive scoring play, so offense_score_play alone cannot
+    # exclude it -- the TD flags are what carry the exclusion
+    offense_score_play = c(1, 1, 0, 1)
+  )
+  expect_equal(.two_pt_decision_rows(df), c(FALSE, FALSE, FALSE, TRUE))
+})
+
+test_that("the TD flags that gate the decision exclude PAT play types", {
+  # Locks the derivation the test above depends on: these play_type values must
+  # not be treated as touchdowns by the exact-match rule in clean_pbp_dat().
+  pat_types <- c("Extra Point Good", "Extra Point Missed",
+                 "Two-Point Conversion Good", "Two-Point Conversion Missed")
+  expect_false(any(pat_types %in% c("Passing Touchdown")))
+  expect_false(any(pat_types %in% c("Rushing Touchdown")))
+})
+
 test_that(".pbp_add_two_pt_prob degrades to NA rather than raising", {
   df <- data.frame(pos_score_diff_start = 0, pass_td = 1, rush_td = 0,
                    offense_score_play = 1)


### PR DESCRIPTION
Follow-up to #142. One gap, no behaviour change.

## The invariant that had nothing holding it

The two-point surface adds **+6** to `pos_score_diff_start` because the PAT shares the touchdown's row, so the pre-TD margin must be advanced to score the decision at the post-TD score.

**Before 2014 the try is its own row**, already post-touchdown. The +6 must never reach those, or the decision gets scored six points further ahead than the game actually was.

Today that holds only **by construction**: `pass_td`/`rush_td` are assigned from an exact `play_type` match (`"Passing Touchdown"` / `"Rushing Touchdown"`) in `clean_pbp_dat()`, so a standalone PAT scores 0 on both and cannot qualify. Nothing enforced it. Broaden that assignment — a regex, or folding in `"Two-Point Conversion Good"` — and the +6 starts firing silently on already-post-TD rows, with no test to notice.

Worth spelling out: **`offense_score_play` cannot carry the exclusion on its own** — a PAT *is* an offensive scoring play. The TD flags are what exclude it, which is precisely why the invariant is worth pinning rather than assuming.

## What's added

Two `test_that` blocks in `test-two_pt_artifacts.R`:

1. `.two_pt_decision_rows()` is `FALSE` for `"Extra Point Good"`, `"Two-Point Conversion Good"` and `"Extra Point Missed"` rows — including when `offense_score_play` is 1 — and `TRUE` for the real `"Passing Touchdown"` row.
2. A guard on the derivation those depend on: PAT play types must not be members of the exact-match TD sets.

## Verified it bites

Relaxing the gate to `offense_score_play` alone turns it red:

```
FAILURE: 'test-two_pt_artifacts.R:88:3'
[ FAIL 1 | WARN 0 | SKIP 2 | PASS 21 ]
```

Restored: `[ FAIL 0 | WARN 0 | SKIP 2 | PASS 22 ]` (the 2 skips are `skip_on_cran`). Run on R 4.6.0.

No source change — tests only.

## Summary by Sourcery

Pin the pre-2014 standalone-PAT exclusion invariant with regression tests.

Enhancements:
- Add regression coverage ensuring standalone pre-2014 PAT rows cannot be treated as two-point decision rows.
- Guard the production touchdown derivation against classifying PAT play types as touchdowns.

Tests:
- Add tests covering standalone PAT decision-row exclusion and the exact-match touchdown classification invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for standalone point-after-attempt rows.
  * Verified these rows are excluded from two-point decision calculations.
  * Confirmed both touchdown flags are derived without point-after-attempt play types.
  * Added checks to detect broadened or pattern-based touchdown classification rules.
  * Continued coverage for conversion scenarios and ensured conversion plays are not classified as passing or rushing touchdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->