### PR TITLE
chore: number the development version 3.0.0.9000, and fix the loader count

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cfbfastR
 Title: Access College Football Play by Play Data
-Version: 3.0.0
+Version: 3.0.0.9000
 Authors@R: c(
     person("Saiem", "Gilani", , "saiem.gilani@gmail.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-7194-9067")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# **cfbfastR (development version)**
+# **cfbfastR 3.0.0.9000 (development version)**
+
+The development version is numbered **3.0.0.9000** so it can be told apart from
+the CRAN **3.0.0** release, which ships the *previous* model generation. Until
+now both builds reported `3.0.0`, so `packageVersion("cfbfastR")` could not
+distinguish them — while producing different EPA/WPA for the same play. A
+four-component version means you are on the GitHub build. See the model note
+below before mixing outputs from the two.
 
 ### Expected Points model now comes from the shared `cfb_model_artifacts` bundle
 
@@ -97,7 +104,7 @@ pre-game line is missing.
 
 # **cfbfastR v3.0.0**
 
-### New release-dataset loaders (39 functions)
+### New release-dataset loaders (48 functions)
 
 `cfbfastR` now loads every published CFB dataset on the
 [sportsdataverse-data](https://github.com/sportsdataverse/sportsdataverse-data/releases)


### PR DESCRIPTION
## Why

The GitHub build and the CRAN release both reported `3.0.0` while producing **different EPA/WPA**. #139 swapped the EP/WP/FG models to the shared `cfb_model_artifacts` bundle but only touched `DESCRIPTION` to raise the xgboost floor, so the version string never moved.

That means anyone following the "install from GitHub to get the new models" advice had no way to confirm which build they were on — `packageVersion("cfbfastR")` returns `3.0.0` either way. It also means `remotes::install_github()` over an installed CRAN 3.0.0 looks like a no-op to version-aware tooling.

## What changed

- **`Version: 3.0.0` → `3.0.0.9000`.** Verified with R that it parses and sorts above `package_version("3.0.0")`, so the GitHub build now resolves as an upgrade.
- **`NEWS.md` gains a note** at the top of the development section: how to tell the builds apart, and that EPA/WPA differ between them.
- **The v3.0.0 NEWS heading said "39 functions"; it is 48.** `NAMESPACE` exports 52 `load_*` functions and exactly four — `load_cfb_pbp`, `load_cfb_rosters`, `load_cfb_schedules`, `load_cfb_teams` — predate the release (verified against `NAMESPACE` at `bc2b3640~1`). The wrong number is published on the pkgdown site.

## Notes

This repo has not used `.9000` suffixes before — it bumped to the next real version during development. `cran-comments.md` records that practice biting once already ("the 2.3.0 development version was renumbered and never published"), which is the argument for the standard suffix here. Bump to `3.1.0` at submission time as usual.

No code, no docs, no roxygen — `DESCRIPTION` and `NEWS.md` only.

## Summary by Sourcery

Identify the GitHub development build separately from CRAN 3.0.0 and correct the release loader count.

Bug Fixes:
- Correct the documented count of v3.0.0 release-dataset loader functions from 39 to 48.

Enhancements:
- Distinguish GitHub development builds from the CRAN 3.0.0 release by numbering the development version 3.0.0.9000 and documenting the resulting EPA/WPA model differences.

Documentation:
- Add development-version guidance explaining how to identify the GitHub build and avoid mixing outputs from different model generations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Information**
  * Updated the development version to **3.0.0.9000** to clearly distinguish it from the CRAN 3.0.0 release.
  * Improved version identification for builds that may produce different EPA/WPA results for the same play.

* **Documentation**
  * Updated release notes to reflect the expanded set of release-dataset loaders, increasing from 39 to 48.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->