### PR TITLE
docs(vignettes): refresh the EP model series for the shipped model, and add Part IV on EPA

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -184,12 +184,14 @@ navbar:
         href: articles/cfbd_teams.html
       - text: ESPN College Football Cookbook
         href: articles/cfbfastR-espn-cookbook.html
-      - text: College Football Expected Points Model Fundamentals - Part I
+      - text: "Expected Points: How the Model Works (Part I)"
         href: articles/college-football-expected-points-model-fundamentals-part-i.html
-      - text: College Football Expected Points Model Fundamentals - Part II
+      - text: "Expected Points: How the Model Is Built (Part II)"
         href: articles/college-football-expected-points-model-fundamentals-part-ii.html
-      - text: College Football Expected Points Model Fundamentals - Part III
+      - text: "Expected Points: A History (Part III)"
         href: articles/college-football-expected-points-model-fundamentals-part-iii.html
+      - text: "What Is EPA? Expected Points Added Explained (Part IV)"
+        href: articles/college-football-expected-points-model-fundamentals-part-iv.html
       - text: Creating Fourth Down Tendency Plots Using cfbfastR
         href: articles/fourth-down-plot-tutorial.html
       - text: Introduction to cfbfastR
@@ -502,6 +504,16 @@ reference:
       - '`csv_from_url`'
       - '`rds_from_url`'
 articles:
+  - title: "The Expected Points Model"
+    desc: >
+      How expected points and EPA work in college football, how the cfbfastR
+      model is built, where the idea came from, and how to reproduce it from
+      the published cfb_model_artifacts bundle.
+    contents:
+      - college-football-expected-points-model-fundamentals-part-i
+      - college-football-expected-points-model-fundamentals-part-ii
+      - college-football-expected-points-model-fundamentals-part-iii
+      - college-football-expected-points-model-fundamentals-part-iv
   - title: "Cookbooks & Guides"
     desc: "End-to-end recipes and reference guides."
     contents:
@@ -513,9 +525,6 @@ articles:
       - cfbd_stats
       - cfbd_teams
       - cfbfastR-espn-cookbook
-      - college-football-expected-points-model-fundamentals-part-i
-      - college-football-expected-points-model-fundamentals-part-ii
-      - college-football-expected-points-model-fundamentals-part-iii
       - fourth-down-plot-tutorial
       - intro
       - map-tutorial

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -168,6 +168,20 @@ navbar:
       menu:
       - text: Vignettes
         href: articles/index.html
+      - text: ---
+      - text: "Expected Points: How the Model Works (Part I)"
+        href: articles/college-football-expected-points-model-fundamentals-part-i.html
+      - text: "Expected Points: How the Model Is Built (Part II)"
+        href: articles/college-football-expected-points-model-fundamentals-part-ii.html
+      - text: "Expected Points: A History (Part III)"
+        href: articles/college-football-expected-points-model-fundamentals-part-iii.html
+      - text: "What Is EPA? Expected Points Added Explained (Part IV)"
+        href: articles/college-football-expected-points-model-fundamentals-part-iv.html
+      - text: "Win Probability: wp, WPA and vegas_wp (Part V)"
+        href: articles/college-football-expected-points-model-fundamentals-part-v.html
+      - text: "CPOE, xpass, Field Goals and Fourth Downs (Part VI)"
+        href: articles/college-football-expected-points-model-fundamentals-part-vi.html
+      - text: ---
       - text: Making Animated Win Probability Charts with cfbfastR
         href: articles/animated-wp-plotting.html
       - text: CFB Data Betting Lines Examples
@@ -184,18 +198,6 @@ navbar:
         href: articles/cfbd_teams.html
       - text: ESPN College Football Cookbook
         href: articles/cfbfastR-espn-cookbook.html
-      - text: "Expected Points: How the Model Works (Part I)"
-        href: articles/college-football-expected-points-model-fundamentals-part-i.html
-      - text: "Expected Points: How the Model Is Built (Part II)"
-        href: articles/college-football-expected-points-model-fundamentals-part-ii.html
-      - text: "Expected Points: A History (Part III)"
-        href: articles/college-football-expected-points-model-fundamentals-part-iii.html
-      - text: "What Is EPA? Expected Points Added Explained (Part IV)"
-        href: articles/college-football-expected-points-model-fundamentals-part-iv.html
-      - text: "Win Probability: wp, WPA and vegas_wp (Part V)"
-        href: articles/college-football-expected-points-model-fundamentals-part-v.html
-      - text: "CPOE, xpass, Field Goals and Fourth Downs (Part VI)"
-        href: articles/college-football-expected-points-model-fundamentals-part-vi.html
       - text: Creating Fourth Down Tendency Plots Using cfbfastR
         href: articles/fourth-down-plot-tutorial.html
       - text: Introduction to cfbfastR

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -192,6 +192,10 @@ navbar:
         href: articles/college-football-expected-points-model-fundamentals-part-iii.html
       - text: "What Is EPA? Expected Points Added Explained (Part IV)"
         href: articles/college-football-expected-points-model-fundamentals-part-iv.html
+      - text: "Win Probability: wp, WPA and vegas_wp (Part V)"
+        href: articles/college-football-expected-points-model-fundamentals-part-v.html
+      - text: "CPOE, xpass, Field Goals and Fourth Downs (Part VI)"
+        href: articles/college-football-expected-points-model-fundamentals-part-vi.html
       - text: Creating Fourth Down Tendency Plots Using cfbfastR
         href: articles/fourth-down-plot-tutorial.html
       - text: Introduction to cfbfastR
@@ -514,6 +518,8 @@ articles:
       - college-football-expected-points-model-fundamentals-part-ii
       - college-football-expected-points-model-fundamentals-part-iii
       - college-football-expected-points-model-fundamentals-part-iv
+      - college-football-expected-points-model-fundamentals-part-v
+      - college-football-expected-points-model-fundamentals-part-vi
   - title: "Cookbooks & Guides"
     desc: "End-to-end recipes and reference guides."
     contents:

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -279,3 +279,13 @@ small.nav-text {
 small.nav-text.text-muted {
   color: #EAEBEC !important;
 }
+
+/* Articles index: separate the Expected Points series from the rest.
+   pkgdown renders one <div class="section"> per `articles:` group. The series is
+   the first group, so a rule above every subsequent group divides it from the
+   standalone cookbooks without hard-coding a section id. */
+.template-article-index main .section + .section {
+  border-top: 1px solid rgba(128, 132, 128, 0.35);
+  margin-top: 2.25rem;
+  padding-top: 1.75rem;
+}

--- a/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
@@ -241,7 +241,12 @@ ep_at <- function(ytg, down = 1, dist = 10, secs = 1800, score_diff = 0) {
     down_3 = as.integer(down == 3), down_4 = as.integer(down == 4),
     pos_score_diff_start = score_diff
   )
-  p <- matrix(predict(ep_model, X), ncol = 7, byrow = TRUE)
+  pred <- predict(ep_model, X)
+  # xgboost >= 1.7 already reshapes multi:softprob output to n x 7; older versions
+  # hand back a flat vector. Re-wrapping an existing matrix with byrow = TRUE reads
+  # it column-major and refills row-major, which silently scrambles the seven
+  # probabilities across rows -- so only reshape when it is not already a matrix.
+  p <- if (is.matrix(pred) && ncol(pred) == 7L) pred else matrix(pred, ncol = 7, byrow = TRUE)
   as.vector(p %*% c(7, -7, 3, -3, 2, -2, 0))
 }
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
@@ -1,10 +1,11 @@
 ---
-title: "College Football Expected Points Model Fundamentals - Part I"
-description: "Expected points model definition - a model explainer"
-author: "Saiem Gilani, Akshay Easwaran, Jared Lee <br><a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://x.com/akeaswaran' target='blank'><img src='https://img.shields.io/twitter/follow/akeaswaran?color=blue&amp;label=%40akeaswaran&amp;logo=x&amp;style=for-the-badge' alt='@akeaswaran'/></a> <a href='https://github.com/akeaswaran' target='blank'><img src='https://img.shields.io/github/followers/akeaswaran?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@akeaswaran'/></a>"
+title: "Expected Points in College Football: How the Model Works (Part I)"
+description: "What expected points (EP) means in college football, the seven next-score outcomes the cfbfastR model predicts, and how to reproduce its field-position curve from the published model bundle."
+author: "Saiem Gilani, Akshay Easwaran, Jared Lee"
+date: "2026-09-03"
 opengraph:
   image:
-    src: "https://github.com/sportsdataverse/cfbfastR-data/blob/main/themes/social_card_cfbfastR_final_quote.png?raw=true"
+    src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
   twitter:
     site: "@cfbfastR"
     card: summary_large_image
@@ -17,173 +18,386 @@ knitr::opts_chunk$set(echo = TRUE)
 old <- options(rmarkdown.html_vignette.check_title = FALSE)
 ```
 
-In this tutorial, we are going to get more familiar with the Expected Points portion of College Football Expected Points Added model.
+**Expected points (EP) is the number of points a team can expect to score, net
+of what its opponent scores, before the next score of the half — given down,
+distance, field position and time.** A first-and-10 on your own 1-yard line is
+worth about −1.3 points. The same down and distance on your opponent's 20 is
+worth about +4. The difference between those two numbers is what makes a
+40-yard gain valuable, and *expected points added* (EPA) is simply the change in
+EP across a single play.
 
-We will be using these ideas as a tool for valuation of plays with the goal of contextualizing team and player performance relative to the average, given the situational factors at the start of the play.
+This article covers what the model predicts and how to reproduce its central
+result. [Part II](college-football-expected-points-model-fundamentals-part-ii.html)
+covers how the model is built and why it is a gradient-boosted classifier.
+[Part III](college-football-expected-points-model-fundamentals-part-iii.html)
+covers where the idea came from.
 
-Let’s dig in.
+## Which model are you running?
 
-## The Data
-We will be acquiring data from [CollegeFootballData.com](collegefootballdata.com), courtesy of \@[CFB\_data](https://twitter.com/CFB_data), using `cfbfastR`, created by [Saiem Gilani](https://twitter.com/saiemgilani), [Akshay Easwaran](https://twitter.com/akeaswaran), [Jared Lee](https://twitter.com/JaredDLee) and [Eric Hess](https://twitter.com/arbitanalytics).
+This matters before anything else, because **two generations of the model are in
+circulation and they give different EPA for the same play.**
 
-# The Expected Points Model
-## Outcome (target) variables
-This model generates probabilities for the possible types of next scoring events within the same half. The 7 scoring possibilities are:
+| | CRAN `cfbfastR 3.0.0` | GitHub `3.0.0.9000` |
+|---|---|---|
+| EP estimator | `nnet::multinom` from `cfbfastR-data` | XGBoost, from the `cfb_model_artifacts` bundle |
+| Agrees with `sportsdataverse-py` | no | yes — same artifact |
+| Mid-era CFBD seasons (~2006–2013) | aborts ([#5](https://github.com/sportsdataverse/cfbfastR/issues/5)) | works |
 
- - Touchdown (7)
- - Field Goal (3)
- - Safety (2)
- - No Score (0)
- - Opponent Safety (-2)
- - Opponent Field Goal (-3)
- - Opponent Touchdown (-7)
-
-For each play, the multinomial logistic regression model calculates what the probability (\emph{p}) of each of those scoring outcomes is and the expected points can be calculated by multiplying each of the scoring event probabilities by their associated point values and summing the products, like so:
-
-<a href="https://imgur.com/sJTs6j6"><img src="https://i.imgur.com/sJTs6j6.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani" /></a>
-
-## Predictive variables
-The model is fit using the following variables and interactions:
-
-### Pure Distance Factors (24 variables)
- - Yards from opponent’s end zone (6)
- - log(yards to convert 1st/Goal) (6)
- - Indicator for goal-to-go situations (6)
- - Interaction between log(yards to convert 1st/Goal) and goal-to-go indicator (6)
-
-### Down Factors and Down Interactions (54 variables)
- - Down (18 since Down is a categorical factor)
- - Interaction between log(yards to convert 1st/Goal) and down (18)
- - Interaction between yards from opponent’s end zone and down (18)
-
-### Time Factors and Intercept (18 variables)
- - Seconds remaining in the current half (6)
- - Indicator for under two-minutes to the end of half/game (6)
- - Intercept for each next score type, used as the combined mean value for reference variables, in this case 1st Down, not a goal-to-go situation and outside of under two minutes left to the end of half or game. (6)
-
-You might be asking at this point, “how are there 96 variables, if there are only 10 bullet points here?” (skip to the next section if you didn’t ask.)  The answer is a little technical if answered completely, but to model this appropriately, one next score type is used as the reference target (we chose “No Score” as our reference) and the coefficients are fitted to the predictive variables for each of the remaining 6 target score types. This is why you see each factor comprising at least 6 variables.
-
-The additional complexity is that down must be treated as a categorical factor, meaning 1st down is treated as the reference and there are then 6 variables for 2nd down, 6 variables for 3rd down, and 6 variables for 4th down. The same logic would then also apply to each of the down interactions. The Boolean indicators for goal-to-go and under two-minutes are also factors that give relative coefficients to the ‘False’ case, but since there only two cases, only 6 additional variables are created for each.
-
-## Model Weights
-Observations are weighted by both score differential and difference in number of drives between play and the next score. The former weighting is intended to accomplish the goal of valuing plays where the score differential is higher less than possessions where the score differential is closer to zero.
-
-Additionally, the latter model weighting places more emphasis on plays on drives that occur closer to the next scoring drive more than plays on prior drives. An example would be if a game begins with 6 scoreless drives to start before one team scores, the plays of the first drive would have a weight of 1/7*, the plays of the second drive a 2/7 weighting, with the plays of the first scoring drive (i.e. the 7th possession) having a full 7/7 weighting.
-
-*Full disclosure: it would be 7 as the denominator if 6 scoreless drives was the largest distance between scoring drives for the entire season across all games (it could be 12 for the games across the entire season, in which case the values would have been 1/12, 2/12, ..., 7/12.)
-
-This way the model weighs all games with the same denominator and scales the weight of each scoring drive distance to a value between 0 and 1. This same caveat also applies for score differential. Score difference is scaled by largest score differential across all games in a given season. Both of the score differential and scoring drive distance weightings are combined to create a single scaled weighting for each play across each season.
-
-### Kicking, Kickoffs, and Punts
-Field goals and kickoffs are treated separately. The probability that a field goal is made is calculated using a general additive model using the (smoothed) distance of the kick as the predictor, calculated as the yard-line plus an additional 17 yards. Each field goal attempt’s expected points are weighted by the probability it is made (resulting in 3 expected points) and adjusted by the probability of a missed field goal (i.e. Pr(Missed FG) = 1 - Pr(Made FG)) and the resulting change in EPA due to changes in field position, down, etc. that would occur from the missed field goal.
-
-Touch-backs are considered the standard expected outcome for kickoffs and anything returned past the 25 would be a points added situation and vice versa for those not returned to at least the 25. considered
-
-PATs are not currently being treated separately, the extra point is treated as a given, which is less than ideal.
-
-Punts are not treated separately, since their primary effect lies mostly in the change in field position. It is a situation the expected points model is well suited to predict on.
-
-## Field Position and Expected Points
-The model was trained on non-overtime data from 2014-2019 using leave-one-season-out cross-validation. This means the model holds one season for test data validation and uses the remaining seasons as the training set, then uses the trained model to make predictions on the season held out. This process is then iterated for each season in the data.
-
-<a href="https://imgur.com/g5rSRUX"><img src="https://i.imgur.com/g5rSRUXl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani" /></a>
-
-This is the plot of expected points in relation to field position alone, grouped in 10 yard bins and labeled on the plot with the mean expected points for the bin. The point at the bottom left is roughly the expected points from having the ball at the offense’s own 1-yard line, -1.28 expected points. The observed mean expected value for receiving the ball from the offense’s own 21-30-yard line (or 70 to 79 yards from opponent’s end-zone) is 0.29 expected points.
-
-It should be no surprise that as offenses move closer to their opponent’s goal line, the expected points trend upward for the offense. Notice for the point representing the 30-39-yard line grouping, the expected points is right around the value of a field goal. This aligns with one of the common definitions of a scoring opportunity, giving support to the appropriateness of the definition.
-
-The observed average expected points in the red-zone are 4.05 in the 10-19-yard line bin and 5.17 inside the 10, with plays at the 1-yard line averaging 6.06 expected points. Note: There are some plays that were input as yard 0 that I interpreted as an “& inches” situation. There are 66 such plays (compared to 5.3k plays at the 1-yard line) and their observed mean expected points is 4.62.
-
-## Field Position and Expected Points by Down
-Recall that down and down interactions were three of the predictors in the model, so here is the field position view of expected points separated by down. The plot below demonstrates that your expected points are higher (on average) on 1st down than 2nd, and 2nd down than 3rd, etc at every point on the field, except possibly near the offense’s own goal line where there is risk of giving up a safety.
-
-<a href="https://imgur.com/S7etCxQ"><img src="https://i.imgur.com/S7etCxQl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani" /></a>
-
-This graph should be somewhat intuitive, but to understand what the relative expected points difference for each down at the same field position, we are interested in the vertical distance between each of the lines.
-
-## 1st and 2nd Down
-Noting that, we see that difference between 1st and 2nd down is steady across most of the field from left to right, starting wider near the offense’s own goal line and narrowing as the offense progresses toward the opponent’s end-zone.
-
-## 2nd and 3rd Down
-Examining the difference between the 2nd and 3rd down lines, the distance is much wider, doubling the relative difference between 1st and 2nd for most portions of the middle 60 yards of the field.
-
-## 3rd and 4th Down
-Further yet is the 4th down line, which has an interesting track, narrowing closest to the other down lines around the 25 yard line.
-
-Perhaps we should examine the next score probabilities underlying each of these down lines to see what drives these relative differences. More on that in Part 2, coming your way next.
-
-# **Our Authors**
--   [Saiem Gilani](https://x.com/saiemgilani)
-<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
-<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
--   [Akshay Easwaran](https://x.com/akeaswaran)
-<a href='https://x.com/akeaswaran' target='blank'><img src='https://img.shields.io/twitter/follow/akeaswaran?color=blue&amp;label=%40akeaswaran&amp;logo=x&amp;style=for-the-badge' alt='@akeaswaran'/></a>
-<a href='https://github.com/akeaswaran' target='blank'><img src='https://img.shields.io/github/followers/akeaswaran?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@akeaswaran'/></a>
--   [Jared Lee](https://x.com/JaredDLee)
-<a href='https://x.com/JaredDLee' target='blank'><img src='https://img.shields.io/twitter/follow/JaredDLee?color=blue&amp;label=%40JaredDLee&amp;logo=x&amp;style=for-the-badge' alt='@JaredDLee'/></a>
-<a href='https://github.com/Kazink36' target='blank'><img src='https://img.shields.io/github/followers/Kazink36?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@Kazink36'/></a>
--   [Eric Hess](https://x.com/arbitanalytics)
-<a href='https://x.com/arbitanalytics' target='blank'><img src='https://img.shields.io/twitter/follow/arbitanalytics?color=blue&amp;label=%40arbitanalytics&amp;logo=x&amp;style=for-the-badge' alt='@arbitanalytics'/></a>
-<a href='https://github.com/ehess' target='blank'><img src='https://img.shields.io/github/followers/ehess?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@ehess'/></a>
-
-## **Our Contributors**
--   [Michael Egle](https://x.com/deceptivespeed_)
-<a href='https://x.com/deceptivespeed_' target='blank'><img src='https://img.shields.io/twitter/follow/deceptivespeed_?color=blue&amp;label=%40deceptivespeed_&amp;logo=x&amp;style=for-the-badge' alt='@deceptivespeed_'/></a>
-<a href='https://github.com/michaelegle' target='blank'><img src='https://img.shields.io/github/followers/michaelegle?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@michaelegle'/></a>
--   [Nate Manzo](https://x.com/cfbnate)
-<a href='https://x.com/cfbnate' target='blank'><img src='https://img.shields.io/twitter/follow/cfbnate?color=blue&amp;label=%40cfbnate&amp;logo=x&amp;style=for-the-badge' alt='@cfbnate'/></a>
-<a href='https://github.com/natemanzo' target='blank'><img src='https://img.shields.io/github/followers/natemanzo?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@natemanzo'/></a>
--   [Jason DeLoach](https://x.com/CFBNumbers)
-<a href='https://x.com/CFBNumbers' target='blank'><img src='https://img.shields.io/twitter/follow/CFBNumbers?color=blue&amp;label=%40CFBNumbers&amp;logo=x&amp;style=for-the-badge' alt='@CFBNumbers'/></a>
-<a href='https://github.com/CFBNumbers' target='blank'><img src='https://img.shields.io/github/followers/CFBNumbers?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@CFBNumbers'/></a>
--   [Tej Seth](https://x.com/tejfbanalytics)
-<a href='https://x.com/tejfbanalytics' target='blank'><img src='https://img.shields.io/twitter/follow/tejfbanalytics?color=blue&amp;label=%40tejfbanalytics&amp;logo=x&amp;style=for-the-badge' alt='@tejfbanalytics'/></a>
-<a href='https://github.com/tejseth' target='blank'><img src='https://img.shields.io/github/followers/tejseth?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@tejseth'/></a>
--   [Conor McQuiston](https://x.com/ConorMcQ5)
-<a href='https://x.com/ConorMcQ5' target='blank'><img src='https://img.shields.io/twitter/follow/ConorMcQ5?color=blue&amp;label=%40ConorMcQ5&amp;logo=x&amp;style=for-the-badge' alt='@ConorMcQ5'/></a>
-<a href='https://github.com/mcqconor' target='blank'><img src='https://img.shields.io/github/followers/mcqconor?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@mcqconor'/></a>
--   [Tan Ho](https://x.com/_TanHo)
-<a href='https://x.com/_TanHo' target='blank'><img src='https://img.shields.io/twitter/follow/_TanHo?color=blue&amp;label=%40_TanHo&amp;logo=x&amp;style=for-the-badge' alt='@_TanHo'/></a>
-<a href='https://github.com/tanho63' target='blank'><img src='https://img.shields.io/github/followers/tanho63?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@tanho63'/></a>
--   [Keegan Abdoo](https://x.com/KeeganAbdoo)
-<a href='https://x.com/KeeganAbdoo' target='blank'><img src='https://img.shields.io/twitter/follow/KeeganAbdoo?color=blue&amp;label=%40KeeganAbdoo&amp;logo=x&amp;style=for-the-badge' alt='@KeeganAbdoo'/></a>
-<a href='https://github.com/keegan-abdoo' target='blank'><img src='https://img.shields.io/github/followers/keegan-abdoo?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@keegan-abdoo'/></a>
--   [Matt Spencer](https://x.com/Maatspencer)
-<a href='https://x.com/Maatspencer' target='blank'><img src='https://img.shields.io/twitter/follow/Maatspencer?color=blue&amp;label=%40Maatspencer&amp;logo=x&amp;style=for-the-badge' alt='@Maatspencer'/></a>
-<a href='https://github.com/Maatspencer' target='blank'><img src='https://img.shields.io/github/followers/Maatspencer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@Maatspencer'/></a>
--   [Sebastian Carl](https://x.com/mrcaseb)
-<a href='https://x.com/mrcaseb' target='blank'><img src='https://img.shields.io/twitter/follow/mrcaseb?color=blue&amp;label=%40mrcaseb&amp;logo=x&amp;style=for-the-badge' alt='@mrcaseb'/></a>
-<a href='https://github.com/mrcaseb' target='blank'><img src='https://img.shields.io/github/followers/mrcaseb?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@mrcaseb'/></a>
--   [John Edwards](https://x.com/John_B_Edwards)
-<a href='https://x.com/John_B_Edwards' target='blank'><img src='https://img.shields.io/twitter/follow/John_B_Edwards?color=blue&amp;label=%40John_B_Edwards&amp;logo=x&amp;style=for-the-badge' alt='@John_B_Edwards'/></a>
-<a href='https://github.com/john-b-edwards' target='blank'><img src='https://img.shields.io/github/followers/john-b-edwards?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@john-b-edwards'/></a>
--   [Brad Hill](https://x.com/bradisblogging)
-<a href='https://x.com/bradisblogging' target='blank'><img src='https://img.shields.io/twitter/follow/bradisblogging?color=blue&amp;label=%40bradisblogging&amp;logo=x&amp;style=for-the-badge' alt='@bradisblogging'/></a>
-<a href='https://github.com/bradisbrad' target='blank'><img src='https://img.shields.io/github/followers/bradisbrad?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@bradisbrad'/></a>
-
-## **Citation**
-
-To cite the [**`cfbfastR`**](https://cfbfastR.sportsdataverse.org/) R package in publications, use:
-
-BibTeX Citation
-
-```bibtex
-@misc{cfbfastr,
-  author = {Saiem Gilani and Akshay Easwaran and Jared Lee and Eric Hess},
-  title = {cfbfastR: Access College Football Play by Play Data},
-  url = {https://cfbfastR.sportsdataverse.org/},
-  year = {2021}
-}
+```{r which-version, eval=FALSE}
+packageVersion("cfbfastR")
+# 3.0.0        -> CRAN build, previous model generation
+# 3.0.0.9000   -> GitHub build, shared bundle
 ```
 
-## **Related SportsDataverse packages**
+The four-component version exists precisely so this is answerable. If you are
+comparing EPA numbers with someone else, compare versions first.
 
--   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
--   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
--   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
--   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
--   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
--   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
--   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
--   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
--   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package
+Everything below describes the **current** generation.
+
+## How the model has evolved
+
+The series originally described a model that no longer ships. The change is
+worth understanding, because it is a real shift in modelling philosophy rather
+than a version bump.
+
+| | 2020 generation | 2026 generation (current) |
+|---|---|---|
+| Estimator | multinomial logistic regression (`nnet::multinom`) | XGBoost, `multi:softprob` |
+| Inputs | **96 model variables** — hand-built interactions and factor expansions | **8 features** |
+| Training data | non-overtime plays, 2014–2019 | 2004–2025, 2,219,971 plays |
+| Validation | leave-one-season-out CV | see the model card |
+| Published as | an `.rda` in `cfbfastR-data` | a versioned release asset both libraries read |
+| Field goals | GAM on smoothed kick distance | a separate gradient-boosted `fg_model` |
+
+The most interesting line is the feature count: **96 variables became 8.**
+
+That is not a loss of information. The old model needed those 96 columns because
+a linear model can only see an interaction if you build the interaction by hand
+— every `log(distance) × down`, every `yards_to_goal × down`, every factor level
+expanded against a reference class. Gradient-boosted trees learn interactions
+from splits, so the same structure is recovered from the raw eight:
+
+```{r ep-features, eval=FALSE}
+c("TimeSecsRem", "yards_to_goal", "distance",
+  "down_1", "down_2", "down_3", "down_4", "pos_score_diff_start")
+```
+
+Note also what is *new* in that list: `pos_score_diff_start`. The current model
+knows the score. The old one did not — it handled game state through observation
+weights instead.
+
+The second shift is organisational. The models are now published once, as the
+[`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+release on
+[`sportsdataverse-data`](https://github.com/sportsdataverse/sportsdataverse-data),
+and read by **both `cfbfastR` and `sportsdataverse-py`**. One artifact, two
+languages, identical EPA for a given play. Retraining is a publish, not a
+release of either library ([#138](https://github.com/sportsdataverse/cfbfastR/issues/138)).
+
+## What the model predicts
+
+The model does not predict points directly. It predicts **which team scores
+next in this half, and how** — a seven-class problem:
+
+| Outcome | Points |
+|---|---|
+| Touchdown | 7 |
+| Field goal | 3 |
+| Safety | 2 |
+| No score | 0 |
+| Opponent safety | −2 |
+| Opponent field goal | −3 |
+| Opponent touchdown | −7 |
+
+Expected points is then the probability-weighted sum:
+
+$$\mathrm{EP} = \sum_{i=1}^{7} p_i \cdot v_i$$
+
+where $p_i$ is the model's probability for outcome $i$ and $v_i$ its point value.
+A play with a 40% touchdown probability, 30% field goal, 20% no score and 10%
+opponent touchdown is worth $0.4(7) + 0.3(3) + 0.2(0) + 0.1(-7) = 2.9$ expected
+points.
+
+Two details matter for anyone reproducing this:
+
+- **Point values are signed from the offense's perspective.** An opponent
+  touchdown is −7, not 7.
+- **The class order in the bundle is not `cfbfastR`'s historical order.** The
+  bundle emits `TD, Opp_TD, FG, Opp_FG, Safety, Opp_Safety, No_Score`;
+  `cfbfastR` reports `No_Score, FG, Opp_FG, Opp_Safety, Opp_TD, Safety, TD`.
+  The permutation between them is published in the manifest rather than
+  hard-coded, so an upstream reordering cannot silently corrupt EPA.
+
+## Reproducing this yourself
+
+The whole bundle is public and every asset is checksummed. Nothing below needs
+an API key.
+
+```{r bundle-manifest, eval=FALSE}
+library(jsonlite)
+
+base <- paste0(
+  "https://github.com/sportsdataverse/sportsdataverse-data/",
+  "releases/download/cfb_model_artifacts/"
+)
+
+manifest <- jsonlite::fromJSON(paste0(base, "MANIFEST.json"))
+
+manifest$model_version          # "2026.08.27"
+manifest$consumers              # "cfbfastR (R)", "sportsdataverse-py (Python)"
+manifest$ep_class_contract$class_order
+#> "TD" "Opp_TD" "FG" "Opp_FG" "Safety" "Opp_Safety" "No_Score"
+manifest$ep_class_contract$point_values
+#>  7 -7  3 -3  2 -2  0
+```
+
+Every model ships a card recording exactly how it was trained:
+
+```{r model-card, eval=FALSE}
+card <- jsonlite::fromJSON(paste0(base, "ep_model.card.json"))
+str(card)
+```
+
+which currently reports:
+
+| Field | Value |
+|---|---|
+| `objective` | `multi:softprob` |
+| `n_features` | 8 |
+| `training_seasons` | 2004–2025 |
+| `n_training_rows` | 2,219,971 |
+| `num_boost_round` | 525 |
+| `max_depth` / `eta` | 5 / 0.025 |
+| `xgboost_version` | 3.2.0 |
+| `trained_date` | 2026-08-02 |
+
+### Scoring a play by hand
+
+To show there is no magic in EP, score one situation directly against the
+downloaded booster:
+
+```{r score-by-hand, eval=FALSE}
+library(xgboost)
+
+f <- tempfile(fileext = ".ubj")
+download.file(paste0(base, "ep_model.ubj"), f, mode = "wb")
+ep_model <- xgboost::xgb.load(f)
+
+# 1st and 10 at your own 25, tied, 30 minutes left in the half
+x <- matrix(
+  c(1800, 75, 10, 1, 0, 0, 0, 0), nrow = 1,
+  dimnames = list(NULL, c("TimeSecsRem", "yards_to_goal", "distance",
+                          "down_1", "down_2", "down_3", "down_4",
+                          "pos_score_diff_start"))
+)
+
+p <- predict(ep_model, x)                       # 7 class probabilities
+sum(p * c(7, -7, 3, -3, 2, -2, 0))              # bundle class order -> EP
+#> [1] 0.6636
+```
+
+So a routine 1st and 10 after a touchback is worth about **two thirds of a
+point**. Every EPA figure in college football analytics is a difference of two
+numbers computed exactly this way.
+
+The point values must be applied in the **bundle's** order, which is why the
+manifest publishes both orders and the permutation between them.
+
+### Getting EPA on real plays
+
+In practice you never do the above — you ask `cfbfastR` for play-by-play with
+the models already applied:
+
+```{r real-plays, eval=FALSE}
+library(cfbfastR)
+library(dplyr)
+
+pbp <- cfbfastR::load_cfb_pbp(2025)
+
+pbp |>
+  dplyr::filter(!is.na(EPA)) |>
+  dplyr::select(game_id, pos_team, down, distance, yards_to_goal,
+                play_text, ep_before, ep_after, EPA) |>
+  dplyr::slice_head(n = 10)
+```
+
+`ep_before` is EP at the snap, `ep_after` is EP for the next play's situation,
+and `EPA` is the difference — signed so that positive is always good for the
+offense.
+
+## Field position and expected points
+
+The single most recognisable output of an EP model is the curve of expected
+points against field position. Scoring the booster across the field reproduces
+it:
+
+```{r field-position, eval=FALSE}
+library(ggplot2)
+
+ep_at <- function(ytg, down = 1, dist = 10, secs = 1800, score_diff = 0) {
+  X <- cbind(
+    TimeSecsRem = secs, yards_to_goal = ytg, distance = pmin(dist, ytg),
+    down_1 = as.integer(down == 1), down_2 = as.integer(down == 2),
+    down_3 = as.integer(down == 3), down_4 = as.integer(down == 4),
+    pos_score_diff_start = score_diff
+  )
+  p <- matrix(predict(ep_model, X), ncol = 7, byrow = TRUE)
+  as.vector(p %*% c(7, -7, 3, -3, 2, -2, 0))
+}
+
+fp <- data.frame(yards_to_goal = 1:99)
+fp$ep <- ep_at(fp$yards_to_goal)
+
+ggplot(fp, aes(x = yards_to_goal, y = ep)) +
+  geom_line(linewidth = 1) +
+  geom_hline(yintercept = c(0, 3), linetype = "dashed", alpha = 0.4) +
+  scale_x_reverse() +
+  labs(
+    x = "Yards to opponent's end zone", y = "Expected points",
+    title = "Expected points by field position",
+    subtitle = "1st & 10, tied, 30:00 left in the half | model_version 2026.08.27",
+    caption = "cfbfastR | @cfbfastR"
+  ) +
+  theme_minimal()
+```
+
+Values from that curve, on the current model:
+
+| Situation | `yards_to_goal` | EP |
+|---|---|---|
+| Own 1 | 99 | **−1.23** |
+| Own 10 | 90 | −0.30 |
+| Own 25 (touchback) | 75 | +0.66 |
+| Own 40 | 60 | +1.92 |
+| Midfield | 50 | +2.61 |
+| Opponent 40 | 40 | +3.33 |
+| Opponent 25 | 25 | +4.20 |
+| Opponent 10 | 10 | +4.96 |
+| Opponent 1 | 1 | +6.03 |
+
+The shape is the intuition behind every EP-based statistic:
+
+- Deep in your own territory EP is **negative** — the opponent is more likely to
+  score next than you are. At your own 1 it is −1.23.
+- **EP crosses zero at your own 15.** Inside that, possession is a liability.
+- It passes **+3, the value of a field goal, at the opponent's 44.** This is a
+  genuinely satisfying result: the common definition of a "scoring opportunity"
+  as reaching the opponent's 40 was chosen by eye, and the model — which has
+  never been told what a scoring opportunity is — puts the break-even four yards
+  away from it.
+- A touchback is worth about two thirds of a point.
+
+The bundle also ships `cfb_field_position_ep.parquet`, a 99-row
+`yardline_own`/`ep` lookup used elsewhere in the pipeline. Note it is *not* this
+curve — its values are positive across the whole field — so do not substitute
+one for the other.
+
+### By down
+
+Splitting the same curve by down shows what down is worth in points at every
+spot on the field:
+
+```{r by-down, eval=FALSE}
+grid <- expand.grid(yards_to_goal = 1:99, down = 1:4)
+grid$ep <- mapply(function(y, d) ep_at(y, down = d), grid$yards_to_goal, grid$down)
+
+ggplot(grid, aes(x = yards_to_goal, y = ep, colour = factor(down))) +
+  geom_line(linewidth = 1) +
+  scale_x_reverse() +
+  labs(x = "Yards to opponent's end zone", y = "Expected points",
+       colour = "Down",
+       title = "Expected points by field position and down",
+       subtitle = "distance = 10, tied game, 30:00 left in the half") +
+  theme_minimal()
+```
+
+Note the `byrow = TRUE` inside `ep_at()`. `multi:softprob` returns a flat
+row-major vector in some XGBoost versions and an n × 7 matrix in others;
+reshaping column-major silently interleaves plays with each other's
+probabilities. `cfbfastR` guards against this internally, and it is the single
+easiest way to get plausible-looking nonsense when scoring the model yourself.
+
+The vertical gaps between the lines are the interesting part — this is what a
+down is *worth*, in points:
+
+| Spot | 1st | 2nd | 3rd | 4th |
+|---|---|---|---|---|
+| Own 25 | +0.66 | −0.02 | −0.93 | −2.30 |
+| Own 40 | +1.92 | +1.27 | +0.31 | −1.25 |
+| Midfield | +2.61 | +1.95 | +0.85 | −0.88 |
+| Opponent 40 | +3.33 | +2.69 | +1.67 | −0.31 |
+| Opponent 25 | +4.20 | +3.65 | +2.90 | +1.50 |
+| Opponent 10 | +4.96 | +4.39 | +3.59 | +2.58 |
+
+Averaged across the middle 60 yards of the field:
+
+- **1st → 2nd down: 0.65 points.** A steady, modest gap.
+- **2nd → 3rd down: 0.93 points**, about 1.4× the first gap.
+- **3rd → 4th down: 1.59 points**, by far the largest — 4th down is where the
+  possession itself is at stake.
+
+Two things in that table are worth dwelling on. First, **a 4th and 10 is
+negative EP everywhere outside the opponent's 35** — at midfield it is −0.88,
+meaning the opponent is the favourite to score next. That is the whole reason
+punting exists, and the whole reason the fourth-down decision is interesting.
+
+Second, the 3rd → 4th gap is not constant: it peaks at **1.98 points at the
+opponent's 40** and falls steadily to **1.24 at the opponent's 15**. Inside
+field-goal range a 4th down still has value, because three points are reachable
+without converting; at the 40 it does not. The model was never told that field
+goals exist as a separate option in this feature set — it recovered the shape of
+field-goal range from eight columns and two million plays. That is the clearest
+single argument for why the gradient-boosted version needs no hand-specified
+`yards_to_goal × down` interaction term.
+
+## Seeing it applied
+
+[Game on Paper](https://gameonpaper.com) runs these models over every FBS game
+and renders the results: EPA per play, success rate and win probability for any
+game, with a full play-by-play showing `ep_before`, `ep_after` and EPA for each
+snap. Its [advanced stats glossary](https://gameonpaper.com/glossary) defines the
+derived metrics in the same terms used here, and the season leaderboards rank
+every team by [offensive](https://gameonpaper.com/year/2025/teams/offensive) and
+[defensive](https://gameonpaper.com/year/2025/teams/defensive) EPA per play.
+
+It is the fastest way to check your intuition about a number this article
+describes in the abstract.
+
+## Data and artifacts
+
+Everything referenced here is public:
+
+- **Models** —
+  [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+  on `sportsdataverse-data`: nine boosters, a punt distribution, a field-position
+  EP table, per-model cards and a checksummed `MANIFEST.json`.
+- **Season play-by-play** —
+  [`cfbfastR-data`](https://github.com/sportsdataverse/cfbfastR-data), which
+  `load_cfb_pbp()` reads.
+- **Package source** —
+  [`cfbfastR`](https://github.com/sportsdataverse/cfbfastR) and its Python twin
+  [`sportsdataverse-py`](https://github.com/sportsdataverse/sportsdataverse-py).
+- **Raw API data** — [CollegeFootballData.com](https://collegefootballdata.com),
+  courtesy of [@CFB_data](https://x.com/CFB_data).
+
+## Next
+
+[Part II](college-football-expected-points-model-fundamentals-part-ii.html) works
+through *why* this is a multiclass classifier and how the model got from linear
+regression to gradient boosting — including the regressions that do not work, and
+why they fail.
+
+## Citation
+
+```
+Gilani, S., Easwaran, A., Lee, J., and Hess, E. (2026). cfbfastR: Access College
+Football Play by Play Data. R package version 3.0.0.9000.
+https://cfbfastr.sportsdataverse.org
+```
+
+Authors, contributors and related SportsDataverse packages are listed on the
+[package home page](../index.html).
+
+```{r cleanup, include=FALSE}
+options(old)
+```

--- a/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
@@ -242,10 +242,10 @@ ep_at <- function(ytg, down = 1, dist = 10, secs = 1800, score_diff = 0) {
     pos_score_diff_start = score_diff
   )
   pred <- predict(ep_model, X)
-  # xgboost >= 1.7 already reshapes multi:softprob output to n x 7; older versions
-  # hand back a flat vector. Re-wrapping an existing matrix with byrow = TRUE reads
-  # it column-major and refills row-major, which silently scrambles the seven
-  # probabilities across rows -- so only reshape when it is not already a matrix.
+  # predict() may hand back an n x 7 matrix or a flat row-major vector depending on
+  # the xgboost build, so normalise rather than assume. Re-wrapping an existing matrix
+  # with byrow = TRUE reads it column-major and refills row-major, which silently
+  # scrambles the seven probabilities across rows.
   p <- if (is.matrix(pred) && ncol(pred) == 7L) pred else matrix(pred, ncol = 7, byrow = TRUE)
   as.vector(p %*% c(7, -7, 3, -3, 2, -2, 0))
 }

--- a/vignettes/college-football-expected-points-model-fundamentals-part-ii.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-ii.Rmd
@@ -139,7 +139,9 @@ because there are seven classes, means the shipped booster contains **3,675
 trees**. That is a useful sanity check when you load it:
 
 ```{r tree-count, eval=FALSE}
-length(xgboost::xgb.dump(ep_model))   # 3675 = 525 rounds x 7 classes
+# xgb.dump() returns one element per NODE line, so length() is far larger than the
+# tree count. Each tree is introduced by a `booster[i]` header -- count those.
+sum(grepl("^booster\\[", xgboost::xgb.dump(ep_model)))   # 3675 = 525 rounds x 7 classes
 ```
 
 ### What the model actually leans on
@@ -184,7 +186,9 @@ x <- matrix(
                           "down_1", "down_2", "down_3", "down_4",
                           "pos_score_diff_start"))
 )
-p <- predict(ep_model, x)
+# as.numeric(): on xgboost >= 1.7 this is a 1 x 7 matrix, and handing a matrix to
+# data.frame() below would create seven columns against a seven-ROW outcome vector.
+p <- as.numeric(predict(ep_model, x))
 data.frame(
   outcome = c("TD", "Opp_TD", "FG", "Opp_FG", "Safety", "Opp_Safety", "No_Score"),
   prob    = round(p, 4),

--- a/vignettes/college-football-expected-points-model-fundamentals-part-ii.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-ii.Rmd
@@ -186,7 +186,7 @@ x <- matrix(
                           "down_1", "down_2", "down_3", "down_4",
                           "pos_score_diff_start"))
 )
-# as.numeric(): on xgboost >= 1.7 this is a 1 x 7 matrix, and handing a matrix to
+# as.numeric(): predict() may return a 1 x 7 matrix here, and handing a matrix to
 # data.frame() below would create seven columns against a seven-ROW outcome vector.
 p <- as.numeric(predict(ep_model, x))
 data.frame(

--- a/vignettes/college-football-expected-points-model-fundamentals-part-ii.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-ii.Rmd
@@ -1,10 +1,11 @@
 ---
-title: "College Football Expected Points Model Fundamentals - Part II"
-description: "Motivating the regression - I do bad regression to show that a multinomial logistic regression model is necessary"
-author: "Saiem Gilani, Akshay Easwaran, Jared Lee <br><a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://x.com/akeaswaran' target='blank'><img src='https://img.shields.io/twitter/follow/akeaswaran?color=blue&amp;label=%40akeaswaran&amp;logo=x&amp;style=for-the-badge' alt='@akeaswaran'/></a> <a href='https://github.com/akeaswaran' target='blank'><img src='https://img.shields.io/github/followers/akeaswaran?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@akeaswaran'/></a>"
+title: "How the Expected Points Model Is Built (Part II)"
+description: "Why expected points is a multiclass problem, why linear and binary logistic regression fail at it, and how the cfbfastR EP model went from 96 hand-built regression variables to eight gradient-boosted features."
+author: "Saiem Gilani, Akshay Easwaran, Jared Lee"
+date: "2026-09-03"
 opengraph:
   image:
-    src: "https://github.com/sportsdataverse/cfbfastR-data/blob/main/themes/social_card_cfbfastR_final_quote.png?raw=true"
+    src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
   twitter:
     site: "@cfbfastR"
     card: summary_large_image
@@ -17,206 +18,299 @@ knitr::opts_chunk$set(echo = TRUE)
 old <- options(rmarkdown.html_vignette.check_title = FALSE)
 ```
 
-Previously in Part 1, we left off discussing field position and expected points, including a breakdown by down. Generally, what was presented could be considered the most top-level results discussion and model definition information without much depth into how we arrived at the model, or detail on how the predictions the model provides generate the expected points.
+[Part I](college-football-expected-points-model-fundamentals-part-i.html)
+established what expected points is and showed the model's output. This article
+is about *how you get there* — why the problem is shaped the way it is, why the
+obvious approaches fail, and how the shipped model works.
 
-In order to remedy that, I feel it necessary for us to cover some model building methods. This article will show you how we arrive at the model that we currently have from a modeling perspective. The entire purpose of this series of articles is to show you as transparently as I can how the Expected Points model works, how well it works, and how the model is limited.
+The through-line: **predicting expected points is not a regression problem.** It
+looks like one, because the answer is a number. It is not, and understanding why
+explains every design decision that follows.
 
-Additionally, and maybe most importantly, this research is reproducible. The following link contains an [R notebook](https://rpubs.com/saiemgilani/625433) and supporting figures for the article which should be sufficient to work through (it is large, \~284Mb when unzipped). [Link](https://drive.google.com/file/d/1jJZBEUvqvEC9I_0-3TFtKQGww7qICVJ2/view?usp=sharing)
+## The problem is multiclass, not continuous
 
-## The Data
+The naive framing is "predict how many points the offense scores next." Try to
+fit that directly and the problems appear immediately.
 
-We will be acquiring data from [CollegeFootballData.com](collegefootballdata.com), courtesy of \@[CFB\_data](https://twitter.com/CFB_data), using `cfbfastR`, created by [Saiem Gilani](https://twitter.com/saiemgilani), [Akshay Easwaran](https://twitter.com/akeaswaran), [Jared Lee](https://twitter.com/JaredDLee) and [Eric Hess](https://twitter.com/arbitanalytics).
+The target is not continuous. The next score in a half can only be one of seven
+things, and their values are −7, −3, −2, 0, 2, 3 or 7. There is no such thing as
+a 4.5-point outcome. A model that predicts 4.5 is not making a claim any
+football game can satisfy — it is averaging over outcomes it should be
+enumerating.
 
-# Regression Methods
+So the target is *categorical*, and expected points is a quantity you compute
+**afterwards**, from the class probabilities:
 
-<a href="https://imgur.com/rOjdyUC"><img src="https://i.imgur.com/rOjdyUCl.png" title="Figure: @ChrisAlbon"  alt="Figure: @ChrisAlbon"/></a>
+$$\mathrm{EP} = \sum_{i=1}^{7} p_i \cdot v_i$$
 
-**Figure 1**: Regression \| [Chris Albon](https://machinelearningflashcards.com/) (\@[ChrisAlbon](https://twitter.com/chrisalbon?s=20))
+That single reframing is the whole conceptual step. Everything below is about
+estimating the $p_i$ well.
 
-Regression is a set of techniques for estimating relationships between multiple variables on a quantitative target variable, and our focus will be on one of the simplest types of relationships: linear.
+### Why not linear regression
 
-## Linear Regression
+Linear regression assumes the dependent variable is continuous and unbounded,
+that the relationship between predictors and target is linear, that observations
+are independent, and that predictors are not collinear.
 
-<a href="https://imgur.com/MegfSse"><img src="https://i.imgur.com/MegfSsel.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
+Point values violate the first assumption outright. But even setting that aside,
+predictions are unbounded — a linear model will happily tell you a situation is
+worth 9.2 points, which no single scoring event can produce. And the
+relationship is emphatically not linear: expected points changes far faster near
+either goal line than it does at midfield.
 
-**Figure 2**: Linear Regression Model
+### Why not binary logistic regression
 
-### Assumptions
+Logistic regression fixes the boundedness problem. Model "does the offense score
+a touchdown next, yes or no", and predictions live in $[0, 1]$ where
+probabilities belong.
 
--   Dependent variable is continuous, unbounded, and measured on an interval or ratio scale
--   Model has linear relation between independent and dependent variables
--   No outliers present
--   Independence Assumption: Sample observations are independent
--   Absence of multicollinearity between the predictor variables
--   Constant Variance Assumption (homoscedasticity)
--   Normal Distribution of error terms
--   Little or no auto-correlation in the residuals
+But we need seven probabilities that are *mutually exclusive and sum to one*.
+Seven separately-fitted binary models give you seven numbers that do not sum to
+anything in particular. You cannot form a valid expectation from them.
 
-Since scores in football only happen in increments of 2, 3, and 6 (+0, +1, +2), with the additional points in parentheses resulting from extra point attempts, the football scoring scheme is not continuous over an interval or ratio scale without transformation of the target variable.
+### Multinomial logistic regression
 
-While pretending I was unaware of the continuous dependent variable assumption of linear regression, I took a look into producing a linear regression model using down, distance, and yards-to-goal as independent variables using a similarly treated college football dataset but excluding all 4th down plays. I tried to predict on either the next score in the half or points on the drive, and the one that demonstrated the highest adjusted R-squared at 0.5143, the others were quite low.
+The classical fix is to fit the classes simultaneously against a reference
+class, and pass the results through a softmax so they are normalised to sum to
+one. Choose "No Score" as the reference, fit six sets of coefficients against
+it, and the seventh falls out.
 
-Adjusted R-squared is a measure of the percentage of the dependent variable variation explained by the independent variables, in this case 51.43%. Below is the model summary of this fitting with no intercept.
+This is exactly what the 2020 model did — and what Yurko, Ventura and Horowitz
+proposed for football in 2017 ([Part
+III](college-football-expected-points-model-fundamentals-part-iii.html) covers
+that lineage). It is a sound, interpretable and well-understood approach.
 
-<a href="https://imgur.com/HjH1CFw"><img src="https://i.imgur.com/HjH1CFwl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
+It is also where the 96 variables came from.
 
-**Figure 3**: Linear Regression model summary \| Expected Drive-Points model using Down, Distance, and Field Position as factors
+## The cost of linearity: 96 variables
 
-Additionally, the linear model indicates that all three factors are significant at a p=0.001 level, which is at least some evidence that our variables have a relationship with drive points. Here is a plot of the linear regression model fitting.
+A multinomial logit is linear in its predictors. It can only represent an
+interaction if you build that interaction by hand, as a column. Football is
+almost entirely interactions — 3rd and 2 is not "3rd down plus 2 yards to go",
+it is its own situation — so the feature list grew to cover them:
 
-<a href="https://imgur.com/AZVRKf3"><img src="https://i.imgur.com/AZVRKf3l.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
+| Group | Variables |
+|---|---|
+| Distance factors (yards to goal, log distance, goal-to-go, and their interaction) | 24 |
+| Down, and down × distance, down × field position | 54 |
+| Time factors, under-two-minute indicator, intercepts | 18 |
+| **Total** | **96** |
 
-**Figure 4**: Linear Regression model plots \| Expected Drive-Points model using Down, Distance, and Field Position as factors
+Each bullet is six variables because six classes are fitted against the
+reference. Every interaction anyone thought of had to be specified. Every
+interaction nobody thought of was invisible to the model.
 
-In the plot on the top left, there are 4 distinct scoring types clearly visible and the model is trying to fire a shot through to fit all of them. The red line in the top-left would be relatively flat if the residuals of the model fit had constant variance. While there are two other non-zero scoring types, Field Goals and Opponent Field Goals, the data excluded 4th down, so they do not appear on the plot. For clarity, there are in fact 7 next score types when we include the absence of a score, i.e. "No Score", since the absence of a scoring event is also a type of next score.
+There were two further consequences worth naming:
 
-Upon viewing these plots, I quickly realized that several assumptions of linear regression are being violated here, namely the constant variance assumption and normal distribution of error terms (see Figure 4), at minimum. We need to keep adding to our regression toolbox, so let us now take a look at a type of regression that does not restrict us to these assumptions.
+- **The model could not see the score.** Game state was handled through
+  observation *weights* — plays were weighted by score differential and by how
+  many drives away the next score was — rather than as a feature.
+- **Field goals needed a separate model**, a GAM on smoothed kick distance,
+  because the main model had no way to represent "this is makeable."
 
-## Logistic Regression
+## What changed: gradient boosting
 
-Suppose we have a binary output variable Y, let's say Y is a variable that gives a response of 1 if the next score in the half is a TD for the offense and a 0 otherwise. If we wanted to predict the probability that the next score in the half is a TD for the offense, one of the prime candidate models would be logistic regression.
+The current model is an XGBoost `multi:softprob` classifier. It answers the same
+seven-class question and produces probabilities the same way. What changes is
+how the structure is found.
 
-<a href="https://imgur.com/ZePALn7"><img src="https://i.imgur.com/ZePALn7l.png" title="Figure: @ChrisAlbon" alt="Figure: @ChrisAlbon"/></a>
+Boosted trees split on feature values, so an interaction is representable
+without being specified: a tree that splits on `down_3`, then on `distance`,
+then on `yards_to_goal` *is* a three-way interaction, discovered from the data.
+The hand-built columns become unnecessary.
 
-**Figure 5**: Logistic Regression [Chris Albon](https://machinelearningflashcards.com/) (\@[ChrisAlbon](https://twitter.com/chrisalbon?s=20))
+| | 2020 | 2026 |
+|---|---|---|
+| Estimator | `nnet::multinom` | XGBoost `multi:softprob` |
+| Inputs | 96 constructed variables | **8 raw features** |
+| Sees the score | no (weights only) | yes (`pos_score_diff_start`) |
+| Training rows | 2014–2019, non-overtime | **2004–2025, 2,219,971 plays** |
+| Field goals | separate GAM | separate gradient-boosted `fg_model` |
 
-<a href="https://imgur.com/PJXbgfq"><img src="https://i.imgur.com/PJXbgfql.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
+The eight features are simply:
 
-**Figure 6**: Logistic Regression Model
-
-### Assumptions
-
--   Binary logistic regression requires the dependent variable to be binary (i.e. 0/1)
--   There is a linear relationship between the log-odds of the outcome and each of the predictor variables.
--   No outliers present
--   Independence Assumption: Sample observations are independent
--   Absence of multicollinearity between the predictor variables
--   ~~Constant Variance Assumption (homoscedasticity)~~
--   ~~Normal Distribution of error terms~~
--   ~~Little or no auto-correlation in the residuals~~
-
-Now we are attempting to calculate the probability of the next scoring event directly, an essential component of an expected points model. Once we have a model capable of calculating the expectation of the scoring event, e.g. the probability of the next score being an offense touchdown, then we simply have to multiply the probability by the point value of the score to get the expected points.
-
-<a href="https://imgur.com/xw3BvAd"><img src="https://i.imgur.com/xw3BvAdl.png" title="Figure: @ChrisAlbon" alt="Illustration comparing linear vs logistic regression decision boundaries"/></a>
-
-**Figure 7**: Logistic vs. Linear Regression \| [Chris Albon](https://machinelearningflashcards.com/) (\@[ChrisAlbon](https://twitter.com/chrisalbon?s=20))
-
-With that background, we can build our model equation with whatever independent variables we choose to include in the model as shown in Figure 8.
-
-<a href="https://imgur.com/vVaOIZx"><img src="https://i.imgur.com/vVaOIZxl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
-
-**Figure 8**: Offense Touchdown Logit Regression
-
-Below is a model fit to the next score offense touchdown variable using the independent variables yards-to-goal, down, distance, and the interaction between down and distance.
-
-<a href="https://imgur.com/gRTGzMT"><img src="https://i.imgur.com/gRTGzMTl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
-
-**Figure 9**: Offense Touchdown Logistic Regression model summary
-
-Once again we see that all variables in the model are fit are significant at the p \< 0.001 level. In figure 10 below, we can see the probability of the next score in half being a touchdown in relation to field position (yards-to-goal) as the offense progresses down the field.
-
-<a href="https://imgur.com/VVsQ8lm"><img src="https://i.imgur.com/VVsQ8lml.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
-
-**Figure 10**: Field Position and Offense TD probability - Logistic Regression
-
-You might be asking "Yeah, that's great, but you're still only predicting the probability of one scoring type relative to another. You'd need to do this like 6 times, right?" Well, fair point. How does one do logistic regression on a categorical variable that has more than one class?
-
-## Multinomial Logistic Regression (or Softmax regression)
-
-A multinomial logistic regression model uses the independent (predictor) variables and target variable data from the training set to build relationships between the independent variables and each of the classes of the target variable.
-
-<a href="https://imgur.com/c18pbOL"><img src="https://i.imgur.com/c18pbOLl.jpg" title="Figure: @ChrisAlbon" alt="Diagram of multinomial logistic regression and class probabilities"/></a>
-
-**Figure 11**: Multinomial Logistic Regression [Chris Albon](https://machinelearningflashcards.com/) (\@[ChrisAlbon](https://twitter.com/chrisalbon?s=20))
-
-The primary difference between logistic and multinomial logistic regression is the use of the softmax function which re-weights the probabilities generated from each of the individual models so that in total they add to one as seen in Figure 12 below.
-
-<a href="https://imgur.com/EyxYqaM"><img src="https://i.imgur.com/EyxYqaMm.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
-
-**Figure 12**: Softmax function
-
-More specifically, a multinomial logistic regression model is an extension of the binomial logistic regression model because it is a series of logistic regression models estimated simultaneously with the same reference outcome.
-
-<a href="https://imgur.com/bGug8hp"><img src="https://i.imgur.com/bGug8hpl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani"/></a>
-
-**Figure 13**: Multinomial Logistic Regression Football Expected Points Model
-
-The college football expected points (EP) model is a multinomial logistic regression model which generates probabilities for the possible types of next score events within the same half. In our case, we build 6 logistic regression models fit to the next score types --- Offense FG, Offense TD, Offense Safety, Opponent TD, Opponent FG, and Opponent Safety --- all except for the class that is used as the base case (i.e. No Score), since that is accounted for in the intercept, as mentioned in Part 1. Ron Yurko, Sam Ventura, and Max Horowitz originally proposed the multinomial logistic regression expected points model for football in 2017, which we will learn more about in Part 3.
-
-Additionally, now that we have a way to calculate the probabilities of scores, we can calculate the expected points. We will discuss this in Part 4.
-
-# **Our Authors**
--   [Saiem Gilani](https://x.com/saiemgilani)
-<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
-<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
--   [Akshay Easwaran](https://x.com/akeaswaran)
-<a href='https://x.com/akeaswaran' target='blank'><img src='https://img.shields.io/twitter/follow/akeaswaran?color=blue&amp;label=%40akeaswaran&amp;logo=x&amp;style=for-the-badge' alt='@akeaswaran'/></a>
-<a href='https://github.com/akeaswaran' target='blank'><img src='https://img.shields.io/github/followers/akeaswaran?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@akeaswaran'/></a>
--   [Jared Lee](https://x.com/JaredDLee)
-<a href='https://x.com/JaredDLee' target='blank'><img src='https://img.shields.io/twitter/follow/JaredDLee?color=blue&amp;label=%40JaredDLee&amp;logo=x&amp;style=for-the-badge' alt='@JaredDLee'/></a>
-<a href='https://github.com/Kazink36' target='blank'><img src='https://img.shields.io/github/followers/Kazink36?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@Kazink36'/></a>
--   [Eric Hess](https://x.com/arbitanalytics)
-<a href='https://x.com/arbitanalytics' target='blank'><img src='https://img.shields.io/twitter/follow/arbitanalytics?color=blue&amp;label=%40arbitanalytics&amp;logo=x&amp;style=for-the-badge' alt='@arbitanalytics'/></a>
-<a href='https://github.com/ehess' target='blank'><img src='https://img.shields.io/github/followers/ehess?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@ehess'/></a>
-
-## **Our Contributors**
--   [Michael Egle](https://x.com/deceptivespeed_)
-<a href='https://x.com/deceptivespeed_' target='blank'><img src='https://img.shields.io/twitter/follow/deceptivespeed_?color=blue&amp;label=%40deceptivespeed_&amp;logo=x&amp;style=for-the-badge' alt='@deceptivespeed_'/></a>
-<a href='https://github.com/michaelegle' target='blank'><img src='https://img.shields.io/github/followers/michaelegle?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@michaelegle'/></a>
--   [Nate Manzo](https://x.com/cfbnate)
-<a href='https://x.com/cfbnate' target='blank'><img src='https://img.shields.io/twitter/follow/cfbnate?color=blue&amp;label=%40cfbnate&amp;logo=x&amp;style=for-the-badge' alt='@cfbnate'/></a>
-<a href='https://github.com/natemanzo' target='blank'><img src='https://img.shields.io/github/followers/natemanzo?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@natemanzo'/></a>
--   [Jason DeLoach](https://x.com/CFBNumbers)
-<a href='https://x.com/CFBNumbers' target='blank'><img src='https://img.shields.io/twitter/follow/CFBNumbers?color=blue&amp;label=%40CFBNumbers&amp;logo=x&amp;style=for-the-badge' alt='@CFBNumbers'/></a>
-<a href='https://github.com/CFBNumbers' target='blank'><img src='https://img.shields.io/github/followers/CFBNumbers?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@CFBNumbers'/></a>
--   [Tej Seth](https://x.com/tejfbanalytics)
-<a href='https://x.com/tejfbanalytics' target='blank'><img src='https://img.shields.io/twitter/follow/tejfbanalytics?color=blue&amp;label=%40tejfbanalytics&amp;logo=x&amp;style=for-the-badge' alt='@tejfbanalytics'/></a>
-<a href='https://github.com/tejseth' target='blank'><img src='https://img.shields.io/github/followers/tejseth?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@tejseth'/></a>
--   [Conor McQuiston](https://x.com/ConorMcQ5)
-<a href='https://x.com/ConorMcQ5' target='blank'><img src='https://img.shields.io/twitter/follow/ConorMcQ5?color=blue&amp;label=%40ConorMcQ5&amp;logo=x&amp;style=for-the-badge' alt='@ConorMcQ5'/></a>
-<a href='https://github.com/mcqconor' target='blank'><img src='https://img.shields.io/github/followers/mcqconor?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@mcqconor'/></a>
--   [Tan Ho](https://x.com/_TanHo)
-<a href='https://x.com/_TanHo' target='blank'><img src='https://img.shields.io/twitter/follow/_TanHo?color=blue&amp;label=%40_TanHo&amp;logo=x&amp;style=for-the-badge' alt='@_TanHo'/></a>
-<a href='https://github.com/tanho63' target='blank'><img src='https://img.shields.io/github/followers/tanho63?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@tanho63'/></a>
--   [Keegan Abdoo](https://x.com/KeeganAbdoo)
-<a href='https://x.com/KeeganAbdoo' target='blank'><img src='https://img.shields.io/twitter/follow/KeeganAbdoo?color=blue&amp;label=%40KeeganAbdoo&amp;logo=x&amp;style=for-the-badge' alt='@KeeganAbdoo'/></a>
-<a href='https://github.com/keegan-abdoo' target='blank'><img src='https://img.shields.io/github/followers/keegan-abdoo?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@keegan-abdoo'/></a>
--   [Matt Spencer](https://x.com/Maatspencer)
-<a href='https://x.com/Maatspencer' target='blank'><img src='https://img.shields.io/twitter/follow/Maatspencer?color=blue&amp;label=%40Maatspencer&amp;logo=x&amp;style=for-the-badge' alt='@Maatspencer'/></a>
-<a href='https://github.com/Maatspencer' target='blank'><img src='https://img.shields.io/github/followers/Maatspencer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@Maatspencer'/></a>
--   [Sebastian Carl](https://x.com/mrcaseb)
-<a href='https://x.com/mrcaseb' target='blank'><img src='https://img.shields.io/twitter/follow/mrcaseb?color=blue&amp;label=%40mrcaseb&amp;logo=x&amp;style=for-the-badge' alt='@mrcaseb'/></a>
-<a href='https://github.com/mrcaseb' target='blank'><img src='https://img.shields.io/github/followers/mrcaseb?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@mrcaseb'/></a>
--   [John Edwards](https://x.com/John_B_Edwards)
-<a href='https://x.com/John_B_Edwards' target='blank'><img src='https://img.shields.io/twitter/follow/John_B_Edwards?color=blue&amp;label=%40John_B_Edwards&amp;logo=x&amp;style=for-the-badge' alt='@John_B_Edwards'/></a>
-<a href='https://github.com/john-b-edwards' target='blank'><img src='https://img.shields.io/github/followers/john-b-edwards?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@john-b-edwards'/></a>
--   [Brad Hill](https://x.com/bradisblogging)
-<a href='https://x.com/bradisblogging' target='blank'><img src='https://img.shields.io/twitter/follow/bradisblogging?color=blue&amp;label=%40bradisblogging&amp;logo=x&amp;style=for-the-badge' alt='@bradisblogging'/></a>
-<a href='https://github.com/bradisbrad' target='blank'><img src='https://img.shields.io/github/followers/bradisbrad?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@bradisbrad'/></a>
-
-## **Citation**
-
-To cite the [**`cfbfastR`**](https://cfbfastR.sportsdataverse.org/) R package in publications, use:
-
-BibTeX Citation
-
-```bibtex
-@misc{cfbfastr,
-  author = {Saiem Gilani and Akshay Easwaran and Jared Lee and Eric Hess},
-  title = {cfbfastR: Access College Football Play by Play Data},
-  url = {https://cfbfastR.sportsdataverse.org/},
-  year = {2021}
-}
+```{r features, eval=FALSE}
+c("TimeSecsRem", "yards_to_goal", "distance",
+  "down_1", "down_2", "down_3", "down_4", "pos_score_diff_start")
 ```
 
-## **Related SportsDataverse packages**
+Trained with `eta = 0.025`, `max_depth = 5` and 525 boosting rounds — which,
+because there are seven classes, means the shipped booster contains **3,675
+trees**. That is a useful sanity check when you load it:
 
--   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
--   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
--   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
--   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
--   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
--   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
--   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
--   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
--   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package
+```{r tree-count, eval=FALSE}
+length(xgboost::xgb.dump(ep_model))   # 3675 = 525 rounds x 7 classes
+```
+
+### What the model actually leans on
+
+Gain-based importance, computed from the shipped booster:
+
+| Feature | Gain |
+|---|---|
+| `TimeSecsRem` | 30.9% |
+| `yards_to_goal` | 21.9% |
+| `down_4` | 14.5% |
+| `down_3` | 9.4% |
+| `down_1` | 7.9% |
+| `down_2` | 6.9% |
+| `pos_score_diff_start` | 5.0% |
+| `distance` | 3.6% |
+
+```{r importance, eval=FALSE}
+imp <- xgboost::xgb.importance(model = ep_model)
+imp[order(-imp$Gain), c("Feature", "Gain")]
+```
+
+Time is the largest single contributor, which is not obvious until you remember
+what the target is: *the next score in this half*. With thirty minutes left
+almost every drive has a successor; with thirty seconds left, "No Score" becomes
+the overwhelming favourite regardless of field position. The model spends most
+of its capacity on that.
+
+Note also that `down_4` carries more gain than the other three downs combined
+with each other — fourth down is where the possession itself is at risk, and the
+distribution shifts hardest.
+
+## A worked example, end to end
+
+One situation, all the way through. First and 10 at your own 25, tied, thirty
+minutes left in the half:
+
+```{r worked, eval=FALSE}
+x <- matrix(
+  c(1800, 75, 10, 1, 0, 0, 0, 0), nrow = 1,
+  dimnames = list(NULL, c("TimeSecsRem", "yards_to_goal", "distance",
+                          "down_1", "down_2", "down_3", "down_4",
+                          "pos_score_diff_start"))
+)
+p <- predict(ep_model, x)
+data.frame(
+  outcome = c("TD", "Opp_TD", "FG", "Opp_FG", "Safety", "Opp_Safety", "No_Score"),
+  prob    = round(p, 4),
+  value   = c(7, -7, 3, -3, 2, -2, 0)
+)
+```
+
+| Outcome | Probability | Value | Contribution |
+|---|---|---|---|
+| Touchdown | 0.3965 | +7 | +2.7753 |
+| Opponent touchdown | 0.3182 | −7 | −2.2274 |
+| Field goal | 0.1564 | +3 | +0.4691 |
+| Opponent field goal | 0.1185 | −3 | −0.3555 |
+| Safety | 0.0034 | +2 | +0.0068 |
+| Opponent safety | 0.0024 | −2 | −0.0048 |
+| No score | 0.0047 | 0 | 0.0000 |
+| | | | **EP = +0.6635** |
+
+Two thirds of a point, from a near-coin-flip between the two touchdown
+outcomes. That is what "expected points" means concretely: not a prediction that
+0.66 points will be scored, but the average over seven futures, six of which are
+worth something.
+
+### The score-margin feature, and a caveat
+
+Because the current model sees the score, EP at a fixed spot varies with the
+margin:
+
+| Score margin | EP at own 25 |
+|---|---|
+| −21 | −1.38 |
+| −7 | −0.18 |
+| Tied | +0.66 |
+| +7 | +1.71 |
+| +21 | +2.71 |
+
+**Read this carefully.** It does not mean leading causes you to score more from
+your own 25. It means teams that are up 21 are, on average, better teams playing
+worse opponents — the margin is partly a proxy for team quality, and the model
+has no separate team-strength input to separate the two.
+
+This is a real limitation and worth stating plainly: **EP is not opponent- or
+quality-adjusted.** Any team-level metric built by summing EPA inherits that.
+Adjusted versions, like the ones on
+[Game on Paper](https://gameonpaper.com/year/2025/teams/offensive), apply
+opponent and garbage-time corrections *on top of* raw EPA precisely because the
+model itself does not.
+
+## One artifact, two languages
+
+The largest structural change is not statistical. The models are published once
+as the
+[`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+release and read by **both `cfbfastR` and `sportsdataverse-py`**
+([#138](https://github.com/sportsdataverse/cfbfastR/issues/138)). The same play
+gets the same EPA in R and in Python, and a retrain updates both by publishing,
+without a release of either package.
+
+Making that true required pinning down one thing that is easy to get wrong.
+XGBoost emits classes in *its* training order, which is not the order `cfbfastR`
+has always reported:
+
+```{r class-order, eval=FALSE}
+manifest$ep_class_contract$class_order
+#> "TD" "Opp_TD" "FG" "Opp_FG" "Safety" "Opp_Safety" "No_Score"
+
+manifest$ep_class_contract$cfbfastR_lev_order
+#> "No_Score" "FG" "Opp_FG" "Opp_Safety" "Opp_TD" "Safety" "TD"
+
+manifest$ep_class_contract$permutation_to_cfbfastR_lev_1based
+#> 7 3 4 6 2 5 1
+```
+
+The permutation is **published in the manifest and read at runtime**, not
+hard-coded. `cfbfastR` keeps a fallback copy, and a test asserts the two agree —
+so if the bundle is ever retrained with a different class order, the build fails
+loudly instead of silently reporting a touchdown probability as a safety
+probability. There is no fixed point between the two orderings, which is to say
+every position moves, which is to say a mistake here would be catastrophic and
+completely invisible in the output.
+
+If you score the booster yourself, apply the point values in the **bundle's**
+order, as in the worked example above.
+
+## Where the estimates are weakest
+
+Being explicit about limits, since the point of this series is transparency:
+
+- **No team-quality input.** See the score-margin caveat above.
+- **PATs are treated as given.** The extra point is folded into the touchdown
+  value of 7 rather than modelled.
+- **Kickoffs assume a touchback baseline;** returns past the 25 are points added
+  and shorter returns points lost.
+- **Punts are not modelled separately.** Their effect is field position, which
+  the EP model already handles well.
+- **Overtime** is not represented in the next-score-in-half framing.
+- **Era effects** are handled in the FG, two-point, QBR and fourth-down models
+  through explicit `era0`–`era3` features, but the EP model itself has no era
+  term — it pools 2004 through 2025.
+
+## Next
+
+[Part III](college-football-expected-points-model-fundamentals-part-iii.html)
+traces where these ideas came from — Virgil Carter's 1970 paper, the field
+position and down-distance models that followed, and the line that runs through
+`nflscrapR` and `cfbscrapR` to the shared bundle described here.
+
+## Data and artifacts
+
+- **Models** — [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+- **Season play-by-play** — [`cfbfastR-data`](https://github.com/sportsdataverse/cfbfastR-data)
+- **Source** — [`cfbfastR`](https://github.com/sportsdataverse/cfbfastR) · [`sportsdataverse-py`](https://github.com/sportsdataverse/sportsdataverse-py)
+- **Applied, live** — [Game on Paper](https://gameonpaper.com)
+- **Raw API** — [CollegeFootballData.com](https://collegefootballdata.com), courtesy of [@CFB_data](https://x.com/CFB_data)
+
+## Citation
+
+```
+Gilani, S., Easwaran, A., Lee, J., and Hess, E. (2026). cfbfastR: Access College
+Football Play by Play Data. R package version 3.0.0.9000.
+https://cfbfastr.sportsdataverse.org
+```
+
+Authors, contributors and related SportsDataverse packages are listed on the
+[package home page](../index.html).
+
+```{r cleanup, include=FALSE}
+options(old)
+```

--- a/vignettes/college-football-expected-points-model-fundamentals-part-iii.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-iii.Rmd
@@ -1,14 +1,15 @@
 ---
-title: "College Football Expected Points Model Fundamentals - Part III"
-description: "A brief history of expected points models. Learn about Virgil Carter's 1970 paper and the origins of the nflscrapR expected points model (which the cfbscrapR package used). The cfbfastR package includes support for this model as well."
-author: "Saiem Gilani, Akshay Easwaran, Jared Lee <br><a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://x.com/akeaswaran' target='blank'><img src='https://img.shields.io/twitter/follow/akeaswaran?color=blue&amp;label=%40akeaswaran&amp;logo=x&amp;style=for-the-badge' alt='@akeaswaran'/></a> <a href='https://github.com/akeaswaran' target='blank'><img src='https://img.shields.io/github/followers/akeaswaran?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@akeaswaran'/></a>"
+title: "A History of Expected Points Models in Football (Part III)"
+description: "How expected points models evolved in football: Virgil Carter's 1970 paper, The Hidden Game of Football, Brian Burke's LOESS models, the Carnegie Mellon nflscrapR work, and the line that runs to the cfbfastR model shipping today."
+author: "Saiem Gilani, Akshay Easwaran, Jared Lee" 
 opengraph:
   image: 
-    src: "https://github.com/sportsdataverse/cfbfastR-data/blob/main/themes/social_card_cfbfastR_final_quote.png?raw=true"
+    src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
   twitter:
     site: "@cfbfastR"
     card: summary_large_image
     creator: "@saiemgilani"
+date: "2026-09-03"
 output: html_document
 ---
 
@@ -92,118 +93,78 @@ In 2017, Ron Yurko, Sam Ventura, and Max Horowitz from Carnegie Mellon Universit
 
 **Figure 4**: Modeling Expected Points using situational factors to predict the probability of each Next Score type
 
-The current cfbfastR model is providing expected points using the same model fit to college football data and with very similar adjustments. 
+The Carnegie Mellon model is the direct ancestor of everything `cfbfastR` has
+shipped. Through the 2020 generation, the college football model *was* that
+model — a multinomial logistic regression over the same seven next-score
+outcomes, fit to college data with very similar adjustments.
 
-Time to talk about the cfbfastR model, finally! 
+That is no longer what the package ships, and the rest of this article is
+therefore history rather than documentation.
 
-Recall the following figure from part 2.
+## The 2020 generation (retired)
 
-<a href="https://imgur.com/bGug8hp"><img src="https://i.imgur.com/bGug8hpl.png" title="Figure: @SaiemGilani" alt="Figure: @SaiemGilani" /></a>
+For the record, since it is what the earlier versions of this series described
+and what CRAN `cfbfastR 3.0.0` still contains: six logistic regressions fitted
+simultaneously against "No Score" as the reference class, with down treated as a
+factor relative to 1st down. From four independent variables —
 
-**Figure 5**: Multinomial Logistic Regression Football Expected Points Model
+* Down (3 coefficients)
+* Distance, as `log(yards to convert 1st/Goal)` (1)
+* Yards to goal (1)
+* Time remaining in the half, in seconds (1)
 
-The college football expected points (EP) model is a multinomial logistic regression model which generates probabilities for our dependent (target) variable, the possible types of next score events within the same half. 
+— plus two derived booleans (goal-to-go, under two minutes) and the interactions
+between them, the specification expanded to **96 fitted variables**, because a
+linear model can only see an interaction that someone built by hand.
 
-In our case, we build 6 logistic regression models fit to the next score types — Offense FG, Offense TD, Offense Safety, Opponent TD, Opponent FG, and Opponent Safety — all except for the class that is used as the base case (i.e. No Score), since that is accounted for in the intercept, as mentioned in part 1. 
+## The 2026 generation
 
-Since down is a categorical variable, it must be treated as a factor variable, meaning coefficients of the model are given relative to the base case of 1st down. 
+The current model answers the same seven-class question and computes expected
+points the same way, but estimates the probabilities with gradient-boosted trees
+instead — **eight raw features**, 2,219,971 plays from 2004 to 2025, and no
+hand-specified interactions at all. Trees find interactions by splitting, so the
+other 88 columns stopped being necessary.
+[Part II](college-football-expected-points-model-fundamentals-part-ii.html)
+covers that transition in detail.
 
-Thus, we have 2nd down, 3rd down, and 4th down coefficients, with the same reasoning applying to all other interaction variables which include down.
+The other change is organisational, and in the long run probably the more
+important one. The models are no longer fitted inside either library. They are
+published once as the
+[`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+release on
+[`sportsdataverse-data`](https://github.com/sportsdataverse/sportsdataverse-data)
+and read by **both `cfbfastR` and `sportsdataverse-py`**, so R and Python report
+the same EPA for the same play and a retrain reaches both by publishing.
 
-The independent variables are (in parentheses are the number of coefficients fitted to the factor):
+Fifty-five years after Carter and his wife Judy hand-coded 8,373 plays from 56
+games, the same question is answered from 2.2 million plays by an artifact two
+languages download at runtime. The question itself has not changed at all.
 
-* Down (3)
-* Distance (to convert 1st down or goal), transformed as log(yards to convert 1st/Goal) (1)
-* Yards-to-goal (or field position, or yards to opponent goal line) (1)
-* Time remaining in half in seconds (1)
+## Next
 
-From these independent variables, we derive two other boolean variables:
+[Part IV](college-football-expected-points-model-fundamentals-part-iv.html) turns
+expected points into **expected points added** — how the change in EP across a
+play becomes the per-play value that team and player metrics are built from, and
+the sign conventions that trip people up.
+## Data and artifacts
 
-* Goal-to-Go (1)
-* Under two minutes in half (1)
+- **Models** — [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+- **Season play-by-play** — [`cfbfastR-data`](https://github.com/sportsdataverse/cfbfastR-data)
+- **Source** — [`cfbfastR`](https://github.com/sportsdataverse/cfbfastR) · [`sportsdataverse-py`](https://github.com/sportsdataverse/sportsdataverse-py)
+- **Applied, live** — [Game on Paper](https://gameonpaper.com)
+- **Raw API** — [CollegeFootballData.com](https://collegefootballdata.com), courtesy of [@CFB_data](https://x.com/CFB_data)
 
-We also include several interaction terms between our independent and derived variables:
+## Citation
 
-* Interaction between distance as log(yards to convert 1st/Goal) and goal-to-go indicator (1)
-* Interaction between distance as log(yards to convert 1st/Goal) and down (3)
-* Interaction between yards from opponent’s end zone and down (3)
-
-The model outputs the probability predictions of each next score type for every play before the play. Then using the play outcomes to adjust our four main independent variables, it then outputs the model probability predictions for all 7 types post-play. 
-
-Next time will cover the underlying next score type probabilities and their influence on the change in expected points as the offense progresses down the field. 
-
-# **Our Authors**
--   [Saiem Gilani](https://x.com/saiemgilani)
-<a href='https://x.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=x&amp;style=for-the-badge' alt='@saiemgilani'/></a>
-<a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>
--   [Akshay Easwaran](https://x.com/akeaswaran)
-<a href='https://x.com/akeaswaran' target='blank'><img src='https://img.shields.io/twitter/follow/akeaswaran?color=blue&amp;label=%40akeaswaran&amp;logo=x&amp;style=for-the-badge' alt='@akeaswaran'/></a>
-<a href='https://github.com/akeaswaran' target='blank'><img src='https://img.shields.io/github/followers/akeaswaran?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@akeaswaran'/></a>
--   [Jared Lee](https://x.com/JaredDLee)
-<a href='https://x.com/JaredDLee' target='blank'><img src='https://img.shields.io/twitter/follow/JaredDLee?color=blue&amp;label=%40JaredDLee&amp;logo=x&amp;style=for-the-badge' alt='@JaredDLee'/></a>
-<a href='https://github.com/Kazink36' target='blank'><img src='https://img.shields.io/github/followers/Kazink36?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@Kazink36'/></a>
--   [Eric Hess](https://x.com/arbitanalytics)
-<a href='https://x.com/arbitanalytics' target='blank'><img src='https://img.shields.io/twitter/follow/arbitanalytics?color=blue&amp;label=%40arbitanalytics&amp;logo=x&amp;style=for-the-badge' alt='@arbitanalytics'/></a>
-<a href='https://github.com/ehess' target='blank'><img src='https://img.shields.io/github/followers/ehess?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@ehess'/></a>
-
-## **Our Contributors**
--   [Michael Egle](https://x.com/deceptivespeed_)
-<a href='https://x.com/deceptivespeed_' target='blank'><img src='https://img.shields.io/twitter/follow/deceptivespeed_?color=blue&amp;label=%40deceptivespeed_&amp;logo=x&amp;style=for-the-badge' alt='@deceptivespeed_'/></a>
-<a href='https://github.com/michaelegle' target='blank'><img src='https://img.shields.io/github/followers/michaelegle?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@michaelegle'/></a>
--   [Nate Manzo](https://x.com/cfbnate)
-<a href='https://x.com/cfbnate' target='blank'><img src='https://img.shields.io/twitter/follow/cfbnate?color=blue&amp;label=%40cfbnate&amp;logo=x&amp;style=for-the-badge' alt='@cfbnate'/></a>
-<a href='https://github.com/natemanzo' target='blank'><img src='https://img.shields.io/github/followers/natemanzo?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@natemanzo'/></a>
--   [Jason DeLoach](https://x.com/CFBNumbers)
-<a href='https://x.com/CFBNumbers' target='blank'><img src='https://img.shields.io/twitter/follow/CFBNumbers?color=blue&amp;label=%40CFBNumbers&amp;logo=x&amp;style=for-the-badge' alt='@CFBNumbers'/></a>
-<a href='https://github.com/CFBNumbers' target='blank'><img src='https://img.shields.io/github/followers/CFBNumbers?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@CFBNumbers'/></a>
--   [Tej Seth](https://x.com/tejfbanalytics)
-<a href='https://x.com/tejfbanalytics' target='blank'><img src='https://img.shields.io/twitter/follow/tejfbanalytics?color=blue&amp;label=%40tejfbanalytics&amp;logo=x&amp;style=for-the-badge' alt='@tejfbanalytics'/></a>
-<a href='https://github.com/tejseth' target='blank'><img src='https://img.shields.io/github/followers/tejseth?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@tejseth'/></a>
--   [Conor McQuiston](https://x.com/ConorMcQ5)
-<a href='https://x.com/ConorMcQ5' target='blank'><img src='https://img.shields.io/twitter/follow/ConorMcQ5?color=blue&amp;label=%40ConorMcQ5&amp;logo=x&amp;style=for-the-badge' alt='@ConorMcQ5'/></a>
-<a href='https://github.com/mcqconor' target='blank'><img src='https://img.shields.io/github/followers/mcqconor?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@mcqconor'/></a>
--   [Tan Ho](https://x.com/_TanHo)
-<a href='https://x.com/_TanHo' target='blank'><img src='https://img.shields.io/twitter/follow/_TanHo?color=blue&amp;label=%40_TanHo&amp;logo=x&amp;style=for-the-badge' alt='@_TanHo'/></a>
-<a href='https://github.com/tanho63' target='blank'><img src='https://img.shields.io/github/followers/tanho63?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@tanho63'/></a>
--   [Keegan Abdoo](https://x.com/KeeganAbdoo)
-<a href='https://x.com/KeeganAbdoo' target='blank'><img src='https://img.shields.io/twitter/follow/KeeganAbdoo?color=blue&amp;label=%40KeeganAbdoo&amp;logo=x&amp;style=for-the-badge' alt='@KeeganAbdoo'/></a>
-<a href='https://github.com/keegan-abdoo' target='blank'><img src='https://img.shields.io/github/followers/keegan-abdoo?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@keegan-abdoo'/></a>
--   [Matt Spencer](https://x.com/Maatspencer)
-<a href='https://x.com/Maatspencer' target='blank'><img src='https://img.shields.io/twitter/follow/Maatspencer?color=blue&amp;label=%40Maatspencer&amp;logo=x&amp;style=for-the-badge' alt='@Maatspencer'/></a>
-<a href='https://github.com/Maatspencer' target='blank'><img src='https://img.shields.io/github/followers/Maatspencer?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@Maatspencer'/></a>
--   [Sebastian Carl](https://x.com/mrcaseb)
-<a href='https://x.com/mrcaseb' target='blank'><img src='https://img.shields.io/twitter/follow/mrcaseb?color=blue&amp;label=%40mrcaseb&amp;logo=x&amp;style=for-the-badge' alt='@mrcaseb'/></a>
-<a href='https://github.com/mrcaseb' target='blank'><img src='https://img.shields.io/github/followers/mrcaseb?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@mrcaseb'/></a>
--   [John Edwards](https://x.com/John_B_Edwards)
-<a href='https://x.com/John_B_Edwards' target='blank'><img src='https://img.shields.io/twitter/follow/John_B_Edwards?color=blue&amp;label=%40John_B_Edwards&amp;logo=x&amp;style=for-the-badge' alt='@John_B_Edwards'/></a>
-<a href='https://github.com/john-b-edwards' target='blank'><img src='https://img.shields.io/github/followers/john-b-edwards?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@john-b-edwards'/></a>
--   [Brad Hill](https://x.com/bradisblogging)
-<a href='https://x.com/bradisblogging' target='blank'><img src='https://img.shields.io/twitter/follow/bradisblogging?color=blue&amp;label=%40bradisblogging&amp;logo=x&amp;style=for-the-badge' alt='@bradisblogging'/></a>
-<a href='https://github.com/bradisbrad' target='blank'><img src='https://img.shields.io/github/followers/bradisbrad?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@bradisbrad'/></a>
-
-## **Citation**
-
-To cite the [**`cfbfastR`**](https://cfbfastR.sportsdataverse.org/) R package in publications, use:
-
-BibTeX Citation
-
-```bibtex
-@misc{cfbfastr,
-  author = {Saiem Gilani and Akshay Easwaran and Jared Lee and Eric Hess},
-  title = {cfbfastR: Access College Football Play by Play Data},
-  url = {https://cfbfastR.sportsdataverse.org/},
-  year = {2021}
-}
+```
+Gilani, S., Easwaran, A., Lee, J., and Hess, E. (2026). cfbfastR: Access College
+Football Play by Play Data. R package version 3.0.0.9000.
+https://cfbfastr.sportsdataverse.org
 ```
 
-## **Related SportsDataverse packages**
+Authors, contributors and related SportsDataverse packages are listed on the
+[package home page](../index.html).
 
--   [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) - college football
--   [**hoopR**](https://hoopR.sportsdataverse.org/) - men's basketball
--   [**wehoop**](https://wehoop.sportsdataverse.org/) - women's basketball
--   [**baseballr**](https://baseballr.sportsdataverse.org/) - baseball
--   [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) - hockey
--   [**oddsapiR**](https://oddsapiR.sportsdataverse.org/) - betting odds
--   [**sportyR**](https://sportyR.sportsdataverse.org/) - playing surfaces
--   [**sportsdataverse-py**](https://py.sportsdataverse.org/) - the Python package
--   [**sportsdataverse-R**](https://r.sportsdataverse.org/) - the R meta-package
+```{r cleanup, include=FALSE}
+options(old)
+```

--- a/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
@@ -199,7 +199,30 @@ a receiver with four targets and +2.0 EPA per target has told you nothing.
 And reproducing the worked table above, straight from the published model:
 
 ```{r reproduce, eval=FALSE}
-# ep_at() as defined in Part I
+# Self-contained: Part I defines ep_at() inside its own eval=FALSE chunk, so a
+# reader pasting this into a clean session would hit
+# "could not find function 'ep_at'". Both setup steps are repeated here.
+library(xgboost)
+base <- paste0(
+  "https://github.com/sportsdataverse/sportsdataverse-data/",
+  "releases/download/cfb_model_artifacts/"
+)
+f <- tempfile(fileext = ".ubj")
+download.file(paste0(base, "ep_model.ubj"), f, mode = "wb")
+ep_model <- xgboost::xgb.load(f)
+
+ep_at <- function(ytg, down = 1, dist = 10, secs = 1800, score_diff = 0) {
+  X <- cbind(
+    TimeSecsRem = secs, yards_to_goal = ytg, distance = pmin(dist, ytg),
+    down_1 = as.integer(down == 1), down_2 = as.integer(down == 2),
+    down_3 = as.integer(down == 3), down_4 = as.integer(down == 4),
+    pos_score_diff_start = score_diff
+  )
+  pred <- predict(ep_model, X)
+  p <- if (is.matrix(pred) && ncol(pred) == 7L) pred else matrix(pred, ncol = 7, byrow = TRUE)
+  as.vector(p %*% c(7, -7, 3, -3, 2, -2, 0))
+}
+
 before <- ep_at(75, down = 1, dist = 10)          # 1st & 10, own 25
 
 data.frame(

--- a/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
@@ -1,0 +1,292 @@
+---
+title: "What Is EPA in College Football? Expected Points Added Explained (Part IV)"
+description: "EPA (expected points added) is the change in expected points across a single play. How it is calculated, what a good EPA per play looks like, the sign conventions that trip people up, and how to compute it yourself with cfbfastR."
+author: "Saiem Gilani, Akshay Easwaran, Jared Lee"
+date: "2026-09-03"
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
+  twitter:
+    site: "@cfbfastR"
+    card: summary_large_image
+    creator: "@saiemgilani"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+old <- options(rmarkdown.html_vignette.check_title = FALSE)
+```
+
+**EPA — expected points added — is the change in expected points across a single
+play.** If a team's situation was worth 0.66 expected points before the snap and
+1.92 after it, the play was worth **+1.26 EPA**. It is the standard way to put a
+points value on one football play, and nearly every modern team and player
+metric is built by summing or averaging it.
+
+$$\mathrm{EPA} = \mathrm{EP}_{\text{after}} - \mathrm{EP}_{\text{before}}$$
+
+[Part I](college-football-expected-points-model-fundamentals-part-i.html) covers
+what expected points is and
+[Part II](college-football-expected-points-model-fundamentals-part-ii.html) how
+the model estimates it. This article is about turning that into per-play value.
+
+## Why EPA instead of yards
+
+Yards treat every situation as identical. EPA does not, and the difference is
+the entire point.
+
+A 3-yard gain on 3rd and 2 continues a drive. A 3-yard gain on 3rd and 8 ends
+one. Both are "3 yards". Their EPA differs by more than two points, because the
+model knows what happens next in each case.
+
+Start from a routine situation — 1st and 10 at your own 25, tied, thirty minutes
+left in the half — worth **+0.66** expected points. Here is what various outcomes
+of that single play are worth:
+
+| Play outcome | Resulting situation | EP after | **EPA** |
+|---|---|---|---|
+| Gain of 40 | 1st & 10, own 65 | +3.57 | **+2.90** |
+| Gain of 25 | 1st & 10, midfield | +2.61 | **+1.95** |
+| Gain of 15 | 1st & 10, own 40 | +1.92 | **+1.25** |
+| Gain of 8 | 2nd & 2, own 33 | +1.62 | **+0.95** |
+| Gain of 10 | 1st & 10, own 35 | +1.55 | **+0.89** |
+| Gain of 5 | 2nd & 5, own 30 | +0.96 | **+0.30** |
+| Gain of 3 | 2nd & 7, own 28 | +0.30 | **−0.36** |
+| Incompletion | 2nd & 10, own 25 | −0.02 | **−0.69** |
+| Sack for −7 | 2nd & 17, own 18 | −1.13 | **−1.79** |
+| Interception at the spot | Opponent 1st & 10 | −0.66 | **−1.33** |
+| Pick six risk: INT returned to your 10 | Opponent 1st & 10, your 10 | −4.96 | **−5.62** |
+
+Look at rows four and five. **A gain of 8 yards is worth more EPA than a gain of
+10.** Eight yards leaves 2nd and 2; ten yards leaves 1st and 10 five yards
+further downfield. The model prefers 2nd and 2, and it is right to — a 2nd and 2
+converts at a far higher rate than a fresh set of downs needing ten.
+
+That is not a quirk. It is the clearest possible demonstration that **down and
+distance carry more value than raw field position** in the middle of the field,
+and no yards-based statistic can express it.
+
+Notice also that a 3-yard gain on 1st and 10 is *negative*. Gaining yards is not
+automatically good. Gaining fewer than the situation demands is a loss.
+
+## The third-down case
+
+The same idea, sharper. 3rd and 3 at the opponent's 35 is worth **+2.75**:
+
+| Outcome | Resulting situation | EP after | **EPA** |
+|---|---|---|---|
+| Convert, gain of 5 | 1st & 10, opponent 30 | +3.98 | **+1.23** |
+| Stuffed for no gain | 4th & 3, opponent 35 | +0.88 | **−1.87** |
+| Turnover on downs | Opponent ball, their 35 | −1.55 | **−4.30** |
+
+A three-yard gain here is worth +1.23. A no-gain is worth −1.87. **The same
+three yards that were worth −0.36 on 1st and 10 are worth +1.23 on 3rd and 3.**
+
+## Sign conventions
+
+This is where most confusion lives, so it is worth being explicit.
+
+**EPA is always signed from the perspective of the team with the ball at the
+snap.** Positive EPA is good for that offense, negative is bad.
+
+Consequences that catch people out:
+
+- **Defensive EPA is the same number negated.** A defense that allows −0.15
+  EPA/play is *good*. When building defensive metrics you either flip the sign
+  or say "EPA allowed" and remember lower is better. `cfbfastR` reports the
+  offense-signed value; the flip is yours to make.
+- **On a turnover, expected points for the new offense is negated** before
+  differencing. That is why an interception at the spot costs −1.33 rather than
+  −0.66: you lose your own +0.66 *and* hand the opponent an equivalent
+  situation.
+- **Return men differ by play type.** On a kickoff the returning team is the
+  possession team, so returner EPA is positive-good. On a punt return the
+  punting team is the possession team at the snap, so the same raw column needs
+  negating for the returner. This is the single most common error in
+  player-level EPA aggregation.
+- **Penalties** are folded into the play they attach to, so a defensive holding
+  on an incompletion produces one net EPA, not two.
+
+## EPA, EPA per play, and total EPA
+
+Three different statistics that get called "EPA":
+
+| Statistic | What it measures | Use it for |
+|---|---|---|
+| **EPA** (one play) | value of a single play | play-level analysis |
+| **Total EPA** | sum over plays | volume — season value, workhorse backs |
+| **EPA per play** | mean over plays | efficiency — comparing teams and players fairly |
+
+A quarterback with 1,200 total EPA over 500 dropbacks (2.4 per play) is not
+comparable to one with 1,200 over 900 dropbacks. Per-play is almost always the
+right comparison; total EPA is the right way to credit workload.
+
+## What is a good EPA per play?
+
+For **teams**, from the 2025 FBS season as ranked on
+[Game on Paper](https://gameonpaper.com/year/2025/teams/offensive) (adjusted
+offensive EPA per play, 135 teams):
+
+| Rank | Team | Adj. EPA/play |
+|---|---|---|
+| 1 | Vanderbilt | +0.35 |
+| 4 | Ohio State | +0.26 |
+| 11 | Miami | +0.22 |
+| 21 | Georgia | +0.15 |
+| 51 | Pittsburgh | +0.04 |
+| 81 | Kennesaw State | −0.01 |
+| 135 | Ball State | −0.31 |
+
+So, as a rule of thumb for team offenses:
+
+- **above +0.25** — elite, top-five
+- **+0.10 to +0.25** — very good
+- **around 0.00** — average; the median FBS offense sits near zero by construction
+- **below −0.20** — among the worst in the country
+
+The full range across 135 FBS teams is roughly **−0.31 to +0.35**. That is a
+narrower spread than newcomers expect: the gap between the best and worst
+offense in the country is about two thirds of a point per snap.
+
+Note these are *adjusted* — corrected for opponent strength, home field and
+garbage time. Raw EPA per play runs wider and flatters teams with easy
+schedules, which is exactly why the adjustment exists.
+
+## Computing it yourself
+
+`cfbfastR` ships EPA on every play, so normally you just read it:
+
+```{r epa-columns, eval=FALSE}
+library(cfbfastR)
+library(dplyr)
+
+pbp <- cfbfastR::load_cfb_pbp(2025)
+
+pbp |>
+  dplyr::filter(!is.na(EPA)) |>
+  dplyr::select(pos_team, def_pos_team, down, distance, yards_to_goal,
+                play_text, ep_before, ep_after, EPA) |>
+  dplyr::slice_head(n = 10)
+```
+
+Team efficiency, offense and defense, from raw play data:
+
+```{r team-epa, eval=FALSE}
+offense <- pbp |>
+  dplyr::filter(!is.na(EPA)) |>
+  dplyr::group_by(team = pos_team) |>
+  dplyr::summarise(plays = dplyr::n(),
+                   epa_per_play = mean(EPA),
+                   total_epa = sum(EPA), .groups = "drop")
+
+defense <- pbp |>
+  dplyr::filter(!is.na(EPA)) |>
+  dplyr::group_by(team = def_pos_team) |>
+  dplyr::summarise(def_epa_per_play = mean(EPA), .groups = "drop")
+  # lower is better -- these are offense-signed
+
+offense |>
+  dplyr::inner_join(defense, by = "team") |>
+  dplyr::mutate(net = epa_per_play - def_epa_per_play) |>
+  dplyr::arrange(dplyr::desc(net)) |>
+  dplyr::filter(plays > 300)
+```
+
+Note the `plays > 300` filter. Per-play averages over small samples are noisy;
+a receiver with four targets and +2.0 EPA per target has told you nothing.
+
+And reproducing the worked table above, straight from the published model:
+
+```{r reproduce, eval=FALSE}
+# ep_at() as defined in Part I
+before <- ep_at(75, down = 1, dist = 10)          # 1st & 10, own 25
+
+data.frame(
+  outcome = c("gain 8", "gain 10", "gain 15"),
+  ep_after = c(ep_at(67, down = 2, dist = 2),
+               ep_at(65, down = 1, dist = 10),
+               ep_at(60, down = 1, dist = 10))
+) |> transform(EPA = ep_after - before)
+```
+
+## What EPA does not do
+
+Stated plainly, because a metric is only useful if you know its edges:
+
+- **It is not opponent-adjusted.** Raw EPA credits a touchdown against a bad
+  defence exactly like one against a good defence.
+- **It has no team-quality input**, so score margin partly proxies for it — see
+  the caveat in
+  [Part II](college-football-expected-points-model-fundamentals-part-ii.html).
+- **It does not assign credit within a play.** A 40-yard completion produces one
+  EPA figure; how much belongs to the quarterback, the receiver, the line or the
+  coverage bust is a separate modelling problem.
+- **It is descriptive, not predictive.** High EPA per play describes what
+  happened. Predicting next week needs stability adjustments, because
+  explosiveness regresses harder than efficiency.
+- **Garbage time distorts it** unless you filter or weight for win probability.
+
+## Seeing it applied
+
+[Game on Paper](https://gameonpaper.com) computes all of this for every FBS game.
+Any game page shows EPA per play, success rate and a win probability chart, with
+a play-by-play listing `ep_before`, `ep_after` and EPA for every snap — the
+table at the top of this article, for a real game. Season leaderboards rank
+every team by [offensive](https://gameonpaper.com/year/2025/teams/offensive) and
+[defensive](https://gameonpaper.com/year/2025/teams/defensive) EPA per play, and
+players by [passing](https://gameonpaper.com/year/2025/players/passing),
+[rushing](https://gameonpaper.com/year/2025/players/rushing) and
+[receiving](https://gameonpaper.com/year/2025/players/receiving) EPA per play.
+
+## Frequently asked
+
+**Is a high EPA good?**
+For an offense, yes — positive EPA means the play improved its scoring
+expectation. For a defense the sign flips: you want the offense's EPA against
+you to be negative.
+
+**What is a good EPA per play?**
+For an FBS offense, above +0.25 is elite and around 0.00 is average. The full
+2025 range was roughly −0.31 to +0.35.
+
+**What is the difference between EPA and EPA per play?**
+EPA is one play's value; total EPA sums it (a volume measure); EPA per play
+averages it (an efficiency measure).
+
+**Can EPA be negative on a play that gained yards?**
+Yes, and often. A 3-yard gain on 1st and 10 is worth −0.36 EPA, because it
+leaves a worse down and distance than the offense started with.
+
+**Does EPA account for the opponent?**
+Not on its own. Adjusted versions correct for opponent, home field and garbage
+time on top of raw EPA.
+
+## Next
+
+Part V covers **win probability** — the same modelling idea applied to the
+outcome that actually matters, why `vegas_wp` exists alongside `wp`, and how
+WPA differs from EPA in late-game situations.
+
+## Data and artifacts
+
+- **Models** — [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+- **Season play-by-play** — [`cfbfastR-data`](https://github.com/sportsdataverse/cfbfastR-data)
+- **Source** — [`cfbfastR`](https://github.com/sportsdataverse/cfbfastR) · [`sportsdataverse-py`](https://github.com/sportsdataverse/sportsdataverse-py)
+- **Applied, live** — [Game on Paper](https://gameonpaper.com)
+- **Raw API** — [CollegeFootballData.com](https://collegefootballdata.com), courtesy of [@CFB_data](https://x.com/CFB_data)
+
+## Citation
+
+```
+Gilani, S., Easwaran, A., Lee, J., and Hess, E. (2026). cfbfastR: Access College
+Football Play by Play Data. R package version 3.0.0.9000.
+https://cfbfastr.sportsdataverse.org
+```
+
+Authors, contributors and related SportsDataverse packages are listed on the
+[package home page](../index.html).
+
+```{r cleanup, include=FALSE}
+options(old)
+```

--- a/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
@@ -219,6 +219,7 @@ ep_at <- function(ytg, down = 1, dist = 10, secs = 1800, score_diff = 0) {
     pos_score_diff_start = score_diff
   )
   pred <- predict(ep_model, X)
+  # normalise: may be an n x 7 matrix or a flat row-major vector
   p <- if (is.matrix(pred) && ncol(pred) == 7L) pred else matrix(pred, ncol = 7, byrow = TRUE)
   as.vector(p %*% c(7, -7, 3, -3, 2, -2, 0))
 }

--- a/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
@@ -1,0 +1,338 @@
+---
+title: "Win Probability in College Football: wp, WPA and vegas_wp (Part V)"
+description: "How the cfbfastR win probability model works, why it takes expected points as an input, what WPA measures that EPA cannot, and how the spread-aware vegas_wp differs from the naive wp."
+author: "Saiem Gilani, Akshay Easwaran, Jared Lee"
+date: "2026-09-03"
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
+  twitter:
+    site: "@cfbfastR"
+    card: summary_large_image
+    creator: "@saiemgilani"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+old <- options(rmarkdown.html_vignette.check_title = FALSE)
+```
+
+**Win probability (WP) is the chance the team with the ball wins the game, given
+the score, time, field position, down, distance and timeouts.** Where
+[expected points](college-football-expected-points-model-fundamentals-part-i.html)
+asks "how many points is this situation worth", win probability asks the question
+that actually settles games — and the two can disagree sharply.
+
+**WPA — win probability added — is the change in WP across a play**, exactly
+parallel to
+[EPA](college-football-expected-points-model-fundamentals-part-iv.html):
+
+$$\mathrm{WPA} = \mathrm{WP}_{\text{after}} - \mathrm{WP}_{\text{before}}$$
+
+## Why not just use EPA?
+
+Because points and wins are the same thing only in the middle of a game.
+
+Down 3 with a minute left, a 12-yard completion to the opponent's 30 is worth
+modest EPA — a few tenths of a point. It is worth enormous WPA, because it moves
+a field goal from unlikely to routine. Conversely, a 60-yard touchdown while up
+28 in the fourth quarter is worth large EPA and almost exactly zero WPA. You had
+already won.
+
+The distinction matters whenever you rank *plays* or evaluate *decisions*. EPA
+is the better measure of performance, because it is not distorted by score and
+clock. WPA is the better measure of leverage, because it is.
+
+## What the model uses
+
+The naive model is a gradient-boosted binary classifier over twelve features:
+
+| Feature | What it carries |
+|---|---|
+| `pos_score_diff_start` | current score margin |
+| `ExpScoreDiff_Time_Ratio` | expected margin per second remaining |
+| `adj_TimeSecsRem` | seconds left **in the game** |
+| `TimeSecsRem` | seconds left in the half |
+| `is_home` | home field |
+| `pos_team_receives_2H_kickoff` | who gets the ball after halftime |
+| `down`, `distance`, `yards_to_goal` | the situation |
+| `pos_team_timeouts_rem_before`, `def_pos_team_timeouts_rem_before` | clock control |
+| `period` | quarter |
+
+Gain-based importance from the shipped booster:
+
+| Feature | Gain |
+|---|---|
+| `pos_score_diff_start` | 53.1% |
+| `ExpScoreDiff_Time_Ratio` | 25.6% |
+| `is_home` | 11.5% |
+| `pos_team_receives_2H_kickoff` | 3.5% |
+| `yards_to_goal` | 2.0% |
+| `adj_TimeSecsRem` | 1.5% |
+| everything else | < 1% each |
+
+Nearly 80% of the model is *score margin and score margin scaled by time*. That
+is the correct shape for the problem — football win probability is overwhelmingly
+about the lead and how long the opponent has to erase it — but it is worth
+knowing before you over-interpret a WP swing on a 2nd-and-7.
+
+### Expected points is an input to win probability
+
+The second-most important feature is built from EP:
+
+```{r expscorediff, eval=FALSE}
+adj_TimeSecsRem          <- ifelse(half == 1, 1800 + TimeSecsRem, TimeSecsRem)
+ExpScoreDiff             <- pos_score_diff_start + ep_before
+ExpScoreDiff_Time_Ratio  <- ExpScoreDiff / (adj_TimeSecsRem + 1)
+```
+
+`ExpScoreDiff` is **the current margin plus what the current drive is worth** —
+in effect, the score once this possession resolves. Dividing by time remaining
+turns it into "how big is the effective lead, relative to how long is left to do
+something about it."
+
+So the four articles before this one are not a detour. The EP model feeds the WP
+model directly: a better EP estimate is a better WP estimate.
+
+## What the numbers look like
+
+Scoring the naive model for a home team with all timeouts:
+
+| Situation | WP |
+|---|---|
+| 1st & 10 own 25, tied, opening drive | **0.573** |
+| 1st & 10 own 25, down 7, Q1 | 0.318 |
+| 1st & 10 own 25, up 7, Q1 | 0.792 |
+| 1st & 10 own 25, tied, Q4 5:00 | 0.648 |
+| 1st & 10 own 25, down 3, Q4 2:00 | 0.255 |
+| 4th & 2 opp 35, down 2, Q4 1:00 | 0.400 |
+| 1st & goal opp 5, down 4, Q4 0:30 | 0.846 |
+| 1st & 10 own 25, up 21, Q4 10:00 | 0.998 |
+
+Two of these are worth pausing on.
+
+**The opening drive is 0.573, not 0.500.** That is home-field advantage, and it
+is why `is_home` carries 11.5% of the model's gain. A tied game is not a coin
+flip if you are the home team.
+
+**1st and goal from the 5, trailing by 4, with thirty seconds left is 0.846.**
+Down by more than a field goal, needing a touchdown, with almost no time — and
+you are a heavy favourite, because you are five yards from the win with four
+downs to get there. No expected-points figure conveys that. This is precisely the
+kind of situation where EPA and WPA part company.
+
+```{r wp-columns, eval=FALSE}
+library(cfbfastR)
+library(dplyr)
+
+pbp <- cfbfastR::load_cfb_pbp(2025)
+
+pbp |>
+  dplyr::filter(!is.na(wpa)) |>
+  dplyr::select(pos_team, period, clock.minutes, pos_score_diff_start,
+                play_text, wp_before, wp_after, wpa, vegas_wp) |>
+  dplyr::arrange(dplyr::desc(abs(wpa))) |>
+  dplyr::slice_head(n = 10)
+```
+
+Sorting by `abs(wpa)` is the quickest way to find the plays that decided a
+season.
+
+## WPA and its edge cases
+
+`wp_after = wp_before + wpa`, and the defensive view is simply `1 - wp_after` —
+win probability is zero-sum in a way expected points is not.
+
+Two overlays are applied that a naive difference would get wrong:
+
+- **Turnovers.** Possession changes hands, so the raw model output is for the
+  *other* team. WPA is computed against the complement, the same way EPA negates
+  expected points across a change of possession.
+- **End of half and end of period.** A play that ends a half does not hand the
+  next situation to anyone in the usual sense; `wpa_half_end` handles the
+  transition so the last snap of a half is not credited with a phantom swing.
+
+These are the same two places EPA needs care, for the same reason.
+
+## `vegas_wp`: what the market knew
+
+The naive model treats both teams as anonymous. Kickoff between the best team in
+the country and the worst is 50/50 plus home field, because nothing in those
+twelve features says who is playing.
+
+That is a defensible choice — it measures *in-game* leverage without prejudice —
+but it is wrong as a forecast. So a second model adds one feature:
+
+```{r spread-time, eval=FALSE}
+elapsed_share <- pmax((3600 - adj_TimeSecsRem) / 3600, 0)
+spread_time   <- pos_team_spread * exp(-4 * elapsed_share)
+```
+
+`spread_time` is the pre-game line, **exponentially decayed as the game runs
+down**. The market's opinion should dominate before any football has been
+played, and count for less once sixty minutes of evidence exist. This is a
+faithful port of the `nflfastR` / `sportsdataverse-py` construction, decay
+constant included.
+
+| Game point | `adj_TimeSecsRem` | Elapsed | `spread_time` (7-point line) |
+|---|---|---|---|
+| Kickoff | 3600 | 0.00 | 7.00 |
+| End of Q1 | 2700 | 0.25 | 2.58 |
+| Halftime | 1800 | 0.50 | 0.95 |
+| End of Q3 | 900 | 0.75 | 0.35 |
+| 2:00 left | 120 | 0.97 | 0.15 |
+| Final gun | 0 | 1.00 | 0.13 |
+
+### The feature decays much faster than its influence
+
+It is tempting to read that table as "by halftime the spread counts for 13% of
+what it did at kickoff." **That is wrong, and it is worth understanding why.**
+
+`spread_time` is an *input*. What matters is the model's response to it, which is
+a learned, non-linear function — and a tree ensemble is free to react sharply to
+small values. Measuring the actual effect, as the gap between `vegas_wp` and the
+naive `wp` in an otherwise identical state, expressed as a share of the same gap
+at kickoff:
+
+| Line | Kickoff | Q1 end | Halftime | Q3 end | Q4 10:00 |
+|---|---|---|---|---|---|
+| +7 | 100% | 61% | 62% | 27% | −15% |
+| +10 | 100% | 70% | 55% | 28% | 16% |
+| +14 | 100% | 84% | 64% | 36% | 23% |
+| +21 | 100% | 85% | 67% | 43% | 31% |
+| −14 (underdog has ball) | 100% | 99% | 82% | 61% | 50% |
+
+**Roughly 55–80% of the spread's influence survives to halftime**, not 13%. The
+model compensates for the shrinking feature by responding to it more steeply. The
+exponential decay sets the *scale* the model trains against; it does not set the
+weight the model gives it.
+
+### Where this gets unreliable
+
+The same table shows a real limitation, and it is not one to paper over.
+
+The decay is **not monotonic**, and at small lines late in games it **changes
+sign**: a 7-point favourite is given *lower* `vegas_wp` than the naive model
+through the fourth quarter (−15% at 10:00, −20% at 5:00). A 3-point line is worse
+still — the effect is unstable from the end of the first quarter onward.
+
+This is tree-model behaviour in a thin region: by the fourth quarter
+`|spread_time|` for a modest line has decayed to a few tenths of a point, and the
+model has little training signal to separate 0.2 from −0.2. The artifact is
+largest exactly where the feature is smallest.
+
+Practical guidance:
+
+- `vegas_wp` is most trustworthy **early**, and for **large** lines — which is
+  also when it adds the most over the naive model.
+- Late in close games with a small spread, prefer `wp`. The scoreboard has told
+  you everything the line was going to, and `vegas_wp` is reading noise.
+- Do not difference `vegas_wp` and `wp` to "extract" the market's contribution.
+  That quantity is not stable enough to interpret.
+
+This is the same split `nflfastR` draws between `wp` and `vegas_wp`, and
+`cfbfastR` keeps `wp_before` **completely unchanged** — `vegas_wp` is added
+alongside rather than replacing it, with `vegas_wpa` and `vegas_wp_after`
+derived using the same turnover and half-end overlays.
+
+### Two sign conventions that must agree
+
+This is the sort of thing that produces a confidently backwards win probability
+chart:
+
+- CFBD's `spread` is **negative when the home team is favoured**.
+- The model reads **positive `spread_time` as the team in possession being
+  favoured**.
+
+Those are not the same convention, and the conversion depends on who has the
+ball. The mapping was verified across 83 games rather than assumed — worth
+knowing if you build `spread_time` yourself.
+
+### When is `vegas_wp` `NA`?
+
+Wherever the game has no pre-game line: the ESPN play-by-play path, and CFBD
+before 2013. The column is added as `NA` rather than the stage failing, so
+filter on it rather than assuming it is populated.
+
+```{r which-wp, eval=FALSE}
+# in-game leverage, team-agnostic -- use for play and decision evaluation
+pbp$wp_before
+
+# forecast that knows who is playing -- use for "should they have won?"
+pbp$vegas_wp
+```
+
+**Which should you use?** For evaluating a decision or a play's leverage, the
+naive `wp` is usually right: it asks what this situation is worth to anybody. For
+"how surprising was this result", `vegas_wp` is right, because a 14-point
+comeback against a 21-point favourite is a different event from the same comeback
+against an even opponent.
+
+## Limits
+
+- **Neither model knows anything about the teams beyond the spread.** The naive
+  model knows nothing at all; `vegas_wp` knows only the market's pre-game number.
+- **No injury, weather, or personnel information** enters either.
+- **Overtime is not modelled** in the same framing.
+- **The tails are the hardest part.** A model trained on 2.2 million plays sees
+  very few genuine 0.99 → 0.20 collapses, so extreme values are the least
+  well-estimated. Treat 0.997 and 0.999 as "almost certainly won", not as a
+  meaningful ordering.
+- **Timeouts are in the model but carry under 1% of gain**, which is probably an
+  underweight relative to how much late-game coaches agonise over them.
+
+## Seeing it applied
+
+Every game page on [Game on Paper](https://gameonpaper.com) renders the win
+probability chart for that game, with the play-by-play beneath it showing the WP
+swing on each snap — the plays with the largest `|wpa|` are the ones the chart's
+cliffs correspond to.
+
+## Frequently asked
+
+**What is a good WPA for a single play?**
+Anything above ±0.10 is a genuinely big play; ±0.30 is a game-turning one.
+Regular-season games are usually decided by a handful of plays above 0.15.
+
+**Why is win probability not 50% at kickoff?**
+Home-field advantage. The naive model puts the home team near 0.57 in a tied
+game on the opening drive. With `vegas_wp`, the spread moves it further.
+
+**What is the difference between `wp` and `vegas_wp`?**
+`wp` ignores who is playing; `vegas_wp` adds the pre-game spread, decayed as the
+game progresses. `vegas_wp` is `NA` when no line is available.
+
+**Can win probability be wrong?**
+It is a probability, not a prediction. A team at 0.95 loses one time in twenty,
+and over a season that will happen many times. The model is wrong only if teams
+at 0.95 fail to win about 95% of the time.
+
+## Next
+
+Part VI covers the derived surfaces built on these two models — completion
+probability and CPOE, expected pass rate (`xpass` / `pass_oe`), the field goal
+and two-point models, fourth-down decisions, and QBR.
+
+## Data and artifacts
+
+- **Models** — [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts) (`wp_naive.ubj`, `wp_spread.ubj`)
+- **Season play-by-play** — [`cfbfastR-data`](https://github.com/sportsdataverse/cfbfastR-data)
+- **Source** — [`cfbfastR`](https://github.com/sportsdataverse/cfbfastR) · [`sportsdataverse-py`](https://github.com/sportsdataverse/sportsdataverse-py)
+- **Applied, live** — [Game on Paper](https://gameonpaper.com)
+- **Raw API** — [CollegeFootballData.com](https://collegefootballdata.com), courtesy of [@CFB_data](https://x.com/CFB_data)
+
+## Citation
+
+```
+Gilani, S., Easwaran, A., Lee, J., and Hess, E. (2026). cfbfastR: Access College
+Football Play by Play Data. R package version 3.0.0.9000.
+https://cfbfastr.sportsdataverse.org
+```
+
+Authors, contributors and related SportsDataverse packages are listed on the
+[package home page](../index.html).
+
+```{r cleanup, include=FALSE}
+options(old)
+```

--- a/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
@@ -42,7 +42,8 @@ already won.
 
 The distinction matters whenever you rank *plays* or evaluate *decisions*. EPA
 is the better measure of performance, because it is not distorted by score and
-clock. WPA is the better measure of leverage, because it is.
+clock. WPA is the better measure of leverage, precisely because it *is* — a play
+is worth more WPA exactly when the game state makes it matter more.
 
 ## What the model uses
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
@@ -208,28 +208,53 @@ model compensates for the shrinking feature by responding to it more steeply. Th
 exponential decay sets the *scale* the model trains against; it does not set the
 weight the model gives it.
 
-### Where this gets unreliable
+### The two models do not share a baseline
 
-The same table shows a real limitation, and it is not one to paper over.
+That table has a trap in it, and it is worth being precise because the obvious
+reading is wrong.
 
-The decay is **not monotonic**, and at small lines late in games it **changes
-sign**: a 7-point favourite is given *lower* `vegas_wp` than the naive model
-through the fourth quarter (−15% at 10:00, −20% at 5:00). A 3-point line is worse
-still — the effect is unstable from the end of the first quarter onward.
+`wp_spread` is **well behaved in `spread_time`**. Sweeping the feature from −20
+to +20 with the state held fixed, win probability rises essentially
+monotonically at every point in the game — 0.11 to 0.91 at kickoff — with only a
+handful of tiny decreasing steps out of eighty. A bigger favourite does not get a
+lower win probability. There is no reversal.
 
-This is tree-model behaviour in a thin region: by the fourth quarter
-`|spread_time|` for a modest line has decayed to a few tenths of a point, and the
-model has little training signal to separate 0.2 from −0.2. The artifact is
-largest exactly where the feature is smallest.
+What actually happens is that the two models **disagree about the pick'em case**.
+Setting `spread_time` to exactly zero and comparing:
+
+| Game point | `wp` (naive) | `wp_spread` at `spread_time = 0` | Gap |
+|---|---|---|---|
+| Kickoff | 0.573 | 0.499 | −0.074 |
+| Halftime | 0.595 | 0.517 | −0.077 |
+| End of Q3 | 0.617 | 0.537 | −0.080 |
+| Q4 10:00 | 0.624 | 0.547 | −0.078 |
+| Q4 2:00 | 0.694 | 0.636 | −0.058 |
+
+A **constant offset of roughly −0.08**, present everywhere.
+
+This is not a bug — it is the two models answering different questions. A
+pick'em line for the *home* team means the market rates the visitor as the better
+side by about a field position's worth of home advantage. So `wp_spread` is right
+to say 0.50, and `wp` is right to say 0.573 for an *average* home team. They
+disagree because "no spread information" and "a spread of zero" are different
+statements.
+
+The consequence is the practical one:
+
+**`vegas_wp − wp` is not the market's contribution.** It is the market's
+contribution *plus* a −0.08 baseline difference between two separately-trained
+models. For a modest line late in a game, where the decayed `spread_time` is
+worth only a few hundredths, the offset dominates and the difference goes
+negative — which looks like the spread reversing sign and is nothing of the kind.
 
 Practical guidance:
 
-- `vegas_wp` is most trustworthy **early**, and for **large** lines — which is
-  also when it adds the most over the naive model.
-- Late in close games with a small spread, prefer `wp`. The scoreboard has told
-  you everything the line was going to, and `vegas_wp` is reading noise.
-- Do not difference `vegas_wp` and `wp` to "extract" the market's contribution.
-  That quantity is not stable enough to interpret.
+- Use `wp` **or** `vegas_wp` for a question, and stay in one of them. They are
+  two coherent models, not a model and an adjustment.
+- Do not difference them. The quantity that comes out is dominated by a baseline
+  offset, not by the spread.
+- `vegas_wp` adds the most where the line is large and the game is young, which
+  is exactly where you would want it.
 
 This is the same split `nflfastR` draws between `wp` and `vegas_wp`, and
 `cfbfastR` keeps `wp_before` **completely unchanged** — `vegas_wp` is added

--- a/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
@@ -123,12 +123,32 @@ Five features: `yards_to_goal` and the one-hot era. Kick distance is
 
 A 50-yarder is a coin flip, which is a useful number to carry around.
 
-**Note the tail.** The curve is flat at 0.366 from 60 yards out — the model
-returns the same probability for a 60-yard and a 65-yard attempt. There is
-almost no training data out there (nobody attempts 65-yarders except in
-desperation), so the model has nothing to distinguish them and extrapolates a
-constant. Treat anything beyond about 57 yards as "the model has run out of
-evidence" rather than a real estimate.
+**Era matters, and it is not a rounding effect.** Kicking has genuinely improved,
+and the model captures it — the same 42-yard attempt across the four eras:
+
+| Era | P(make), 42 yards |
+|---|---|
+| `era0` (pre-2006) | 0.556 |
+| `era1` (2006–2012) | 0.598 |
+| `era2` (2013–2019) | 0.612 |
+| `era3` (2020+) | 0.675 |
+
+Twelve percentage points from the oldest era to the current one. The era features
+carry about 20% of the model's gain between them, so scoring a historical kick
+with `era3` — or a modern one with `era0` — is a real error, not a nicety.
+
+**The tail runs out at 57 yards.** From `yards_to_goal` 40 outward the model
+returns a constant **0.3656** — a 57-yard and a 70-yard attempt get identical
+probabilities. Nobody attempts many 65-yarders except in desperation, so there is
+nothing to learn from and the model extrapolates flat. Treat anything past a
+57-yard kick as "the model has run out of evidence" rather than an estimate.
+
+**Two small monotonicity violations.** Across 58 steps the curve rises twice
+where it should fall: a 49-yard kick is rated 0.5882 against 0.5647 for a
+48-yarder, and 51 yards beats 50. Both are sub-3-point artifacts of tree
+splitting rather than anything meaningful, but if you are differencing adjacent
+yard lines — as the fourth-down surface does when it weighs a make against a miss
+— be aware the curve is not strictly monotone.
 
 The model also has **no kicker identity, weather or altitude input**. A kick in
 Laramie and a kick in a dome get the same number.
@@ -139,33 +159,49 @@ Four features: `posteam_spread`, `posteam_total`, `pos_score_diff`, `era`. It
 produces `prob_2pt`, which feeds the two-point decision surface —
 `two_pt_wp`, `xp_wp`, `two_pt_wp_diff` and `two_pt_recommendation`.
 
-Scoring it in an even game with a 55-point total returns **0.578, and does not
-move with the score margin**:
+This model does not work, and it is worth showing exactly how rather than
+gesturing at a caveat.
 
-| Score margin | `prob_2pt` |
-|---|---|
-| −2 | 0.578 |
-| −1 | 0.578 |
-| 0 | 0.578 |
-| +1 | 0.578 |
-| +2 | 0.578 |
+Sweeping each feature with the others held at realistic values:
 
-Two things follow, and both are documented rather than hidden.
+| Feature | Values swept | `prob_2pt` |
+|---|---|---|
+| `pos_score_diff` | −14 → +14 | 0.487 … **0.578** … 0.557 |
+| `posteam_spread` | −28 → +28 | 0.572 … 0.592 |
+| `posteam_total` | 35 → 75 | **0.578 at every value** |
+| `era` | 0 → 3 | **0.578 at every value** |
 
-First, **0.578 is optimistic.** Real college two-point conversion rates run
-closer to 45%. The `NEWS` entry says as much: the bundled model is optimistic
-about college conversion rates.
+The whole model moves between **0.487 and 0.592**. It is very nearly a constant.
 
-Second, because the recommendation compares win probabilities computed from that
-number, **read `two_pt_wp_diff` rather than `two_pt_recommendation`.** `cfb4th`'s
-rule has no margin — it will recommend going for two on a difference of 0.0001 —
-and with an optimistic conversion probability that tips too often toward the
-aggressive call. The magnitude tells you whether the decision is close; the bare
-recommendation does not.
+Three specific problems, from the tree dump:
 
-The surface itself is sound: it was verified **bit-identical to
-`sportsdataverse-py` to eight decimal places**. The caveat is about the input,
-not the arithmetic.
+1. **`era` is never split on.** It appears in the feature list and in no tree.
+   Two-point conversion rates have moved over twenty years; this model cannot
+   express that.
+2. **The `posteam_total` splits are at 21.375 and 31.875.** College football
+   game totals live between about 45 and 65. Every realistic game takes the same
+   branch, which is why sweeping the total from 35 to 75 changes nothing. Those
+   thresholds suggest the training feature was not the game total on the scale it
+   is scored with — a scaling or fill problem upstream, not a modelling choice.
+3. **The first split is `pos_score_diff < -6`.** Almost every genuine two-point
+   decision happens within a touchdown either way, so in the region that matters
+   the model is flat by construction.
+
+And the level is wrong: it centres on **0.578** where real college two-point
+conversion rates run closer to 45%. Note its own `base_score` is 0.4816 — the
+trees push the prediction *above* the base rate for every realistic input.
+
+**Practical consequence.** `prob_2pt` feeds `two_pt_wp`, so an optimistic and
+nearly-constant conversion probability biases the decision surface toward going
+for two, everywhere, regardless of situation. `cfb4th`'s rule has no margin — it
+will recommend two on a difference of 0.0001 — so **read `two_pt_wp_diff` and
+treat anything under a couple of percentage points as a coin flip**, or supply
+your own conversion probability.
+
+To be clear about where the fault lies: the surface's arithmetic is sound and was
+verified **bit-identical to `sportsdataverse-py` to eight decimal places**. The
+problem is entirely the input model. It is a retrain candidate, and until then
+the recommendation column should not be used on its own.
 
 ## The fourth-down decision
 
@@ -277,8 +313,15 @@ How much more often a team passes than its down, distance, score and clock
 suggest. It measures aggression, not effectiveness.
 
 **How accurate is the college field goal model?**
-It gives about 81% at 34 yards and 54% at 50. It has no kicker, weather or
-altitude input, and it flattens beyond roughly 57 yards where data runs out.
+In the modern era (`era3`, 2020+) it gives about 81% at 34 yards and 54% at 50.
+Older eras are materially lower — 42 yards is 0.68 in `era3` against 0.56 in
+`era0`. It has no kicker, weather or altitude input, and flattens beyond roughly
+57 yards where data runs out.
+
+**Should I trust `two_pt_recommendation`?**
+No, not on its own. The underlying `prob_2pt` model is nearly constant at about
+0.578, against real college rates closer to 45%, so the surface is biased toward
+going for two. Read `two_pt_wp_diff` and treat small margins as coin flips.
 
 **Should I trust `fourth_down_recommendation`?**
 Use `go_boost` instead. The recommendation has no margin, so it treats a

--- a/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
@@ -1,0 +1,317 @@
+---
+title: "CPOE, xpass, Field Goals and Fourth Downs: The Derived Models (Part VI)"
+description: "The six models cfbfastR builds on top of expected points and win probability: completion probability and CPOE, expected pass rate, field goals, two-point conversions, fourth-down decisions and QBR — with their real outputs and their limits."
+author: "Saiem Gilani, Akshay Easwaran, Jared Lee"
+date: "2026-09-03"
+opengraph:
+  image:
+    src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
+  twitter:
+    site: "@cfbfastR"
+    card: summary_large_image
+    creator: "@saiemgilani"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+old <- options(rmarkdown.html_vignette.check_title = FALSE)
+```
+
+[Expected points](college-football-expected-points-model-fundamentals-part-i.html)
+and [win probability](college-football-expected-points-model-fundamentals-part-v.html)
+are the foundation. Everything in this article is built on top of them, and all
+of it ships in the same
+[`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+bundle.
+
+There is a useful distinction to draw first. Some of these are **models** — they
+predict a thing and you read the number. Others are **analytic surfaces**: they
+build the game state that *would* follow a choice, score it with the WP model,
+and compare. Fourth down and the two-point decision are surfaces, and they are
+ports of [`cfb4th`](https://github.com/sportsdataverse/cfb4th).
+
+## The bundle at a glance
+
+| Artifact | Objective | Features | Produces |
+|---|---|---|---|
+| `ep_model` | `multi:softprob` (7) | 8 | `ep_before`, `ep_after`, `EPA` |
+| `wp_naive` | `binary:logistic` | 12 | `wp_before`, `wpa` |
+| `wp_spread` | `binary:logistic` | 13 | `vegas_wp` |
+| `cfb_cp_model` | `binary:logistic` | 8 | `cp`, `cpoe` |
+| `xpass_model` | `binary:logistic` | 7 | `xpass`, `pass_oe` |
+| `fg_model` | `binary:logistic` | 5 | field-goal probability |
+| `two_pt_model` | `binary:logistic` | 4 | `prob_2pt` |
+| `fd_model` | `multi:softprob` (**76**) | 9 | fourth-down gain distribution |
+| `qbr_model` | `reg:squarederror` | 10 | QBR |
+
+Plus `punt_distribution.parquet`, which is not a model at all — see below.
+
+## Completion probability and CPOE
+
+`cp` is the probability a given pass attempt is completed, from down, distance,
+field position, score, clock, home field, period and a passing-down indicator.
+**CPOE** is the difference between what happened and what was expected, on a
+percentage-point scale:
+
+$$\mathrm{CPOE} = 100 \times (\text{completion} - \mathrm{cp})$$
+
+| Situation | `cp` |
+|---|---|
+| 1st & 10, own 25 | 0.639 |
+| 3rd & 3, opponent 40 | 0.595 |
+| 2nd & 20, own 20 | 0.627 |
+| 3rd & 12, own 30 | 0.489 |
+
+CPOE is the standard way to separate a quarterback's accuracy from his
+situation. A 65% completion rate throwing 3rd-and-12s is a much better
+performance than 65% throwing 1st-and-10s, and CPOE is what says so.
+
+Note that the model has **no receiver, pressure, or air-yards input** — it is a
+situational baseline, not a throw-difficulty model. A quarterback checking down
+constantly will post good CPOE.
+
+## Expected pass rate (`xpass` and `pass_oe`)
+
+`xpass` is the probability a play *is* a pass, given the situation — a model of
+tendency, not of quality. `pass_oe` (pass rate over expected) is
+`100 * (pass - xpass)`, and measures how much more pass-happy a team is than its
+situations warrant.
+
+| Situation | `xpass` |
+|---|---|
+| 1st & goal, opponent 3 | 0.141 |
+| 2nd & 2, own 33 | 0.247 |
+| 3rd & 2, opponent 40 | 0.255 |
+| 1st & 10, own 25 | 0.373 |
+| 2nd & 8, own 27 | 0.536 |
+| 3rd & 8, opponent 40 | 0.782 |
+
+The spread is the point: 14% on 1st and goal from the 3, 78% on 3rd and 8. Any
+raw pass-rate statistic is mostly measuring which of these situations a team
+found itself in. `pass_oe` removes that.
+
+### An era-encoding trap
+
+The `xpass` model uses an **ordinal** `era` feature cutting at **2006 / 2013 /
+2017**. The FG, two-point and QBR models use **one-hot** `era0`–`era3` cutting at
+**2006 / 2013 / 2020**.
+
+Different encodings *and* different cutpoints, in the same bundle. If you score
+these models by hand, build each one's era feature from its own rule — reusing
+one for the other is silent and wrong. `cfbfastR` handles this internally; it is
+listed here because it is exactly the kind of thing that survives a code review
+and fails in production.
+
+## The field goal model
+
+Five features: `yards_to_goal` and the one-hot era. Kick distance is
+`yards_to_goal + 17`.
+
+| `yards_to_goal` | Kick | P(make) |
+|---|---|---|
+| 2 | 19 | 0.956 |
+| 10 | 27 | 0.893 |
+| 17 | 34 | 0.809 |
+| 20 | 37 | 0.754 |
+| 25 | 42 | 0.675 |
+| 30 | 47 | 0.614 |
+| 33 | 50 | 0.542 |
+| 38 | 55 | 0.455 |
+| 43 | 60 | 0.366 |
+| 48 | 65 | 0.366 |
+
+A 50-yarder is a coin flip, which is a useful number to carry around.
+
+**Note the tail.** The curve is flat at 0.366 from 60 yards out — the model
+returns the same probability for a 60-yard and a 65-yard attempt. There is
+almost no training data out there (nobody attempts 65-yarders except in
+desperation), so the model has nothing to distinguish them and extrapolates a
+constant. Treat anything beyond about 57 yards as "the model has run out of
+evidence" rather than a real estimate.
+
+The model also has **no kicker identity, weather or altitude input**. A kick in
+Laramie and a kick in a dome get the same number.
+
+## The two-point model, and an honest caveat
+
+Four features: `posteam_spread`, `posteam_total`, `pos_score_diff`, `era`. It
+produces `prob_2pt`, which feeds the two-point decision surface —
+`two_pt_wp`, `xp_wp`, `two_pt_wp_diff` and `two_pt_recommendation`.
+
+Scoring it in an even game with a 55-point total returns **0.578, and does not
+move with the score margin**:
+
+| Score margin | `prob_2pt` |
+|---|---|
+| −2 | 0.578 |
+| −1 | 0.578 |
+| 0 | 0.578 |
+| +1 | 0.578 |
+| +2 | 0.578 |
+
+Two things follow, and both are documented rather than hidden.
+
+First, **0.578 is optimistic.** Real college two-point conversion rates run
+closer to 45%. The `NEWS` entry says as much: the bundled model is optimistic
+about college conversion rates.
+
+Second, because the recommendation compares win probabilities computed from that
+number, **read `two_pt_wp_diff` rather than `two_pt_recommendation`.** `cfb4th`'s
+rule has no margin — it will recommend going for two on a difference of 0.0001 —
+and with an optimistic conversion probability that tips too often toward the
+aggressive call. The magnitude tells you whether the decision is close; the bare
+recommendation does not.
+
+The surface itself is sound: it was verified **bit-identical to
+`sportsdataverse-py` to eight decimal places**. The caveat is about the input,
+not the arithmetic.
+
+## The fourth-down decision
+
+This is the most elaborate surface in the package, and the 76-class model is the
+interesting part.
+
+`fd_model` is a `multi:softprob` classifier over **76 classes: yards gained, from
+−10 to +65**. It does not predict whether a fourth down is converted. It predicts
+the *whole distribution* of what happens if you go for it.
+
+The go branch then:
+
+1. Scores the 76-class distribution for the fourth-down state.
+2. Expands the play into **one hypothetical game state per outcome** — every
+   yardage result gets its own down, distance and field position.
+3. Scores each with the win probability model.
+4. Averages, weighted by the distribution.
+
+That average is `go_wp` — the win probability of going for it, integrated over
+everything that could happen.
+
+The punt branch is different again. **`cfb4th` does not model punts.** It joins
+an empirical distribution of punt end-yardlines from
+`punt_distribution.parquet`, expands to one state per landing spot, scores each,
+and averages. The field-goal branch uses the FG model above, weighting a make
+against a miss and the field position each produces.
+
+The outputs:
+
+| Column | Meaning |
+|---|---|
+| `go_wp`, `fg_wp`, `punt_wp` | win probability of each choice |
+| `go_wp_diff`, `fg_wp_diff`, `punt_wp_diff` | each against the best alternative |
+| `go_boost` | how much going for it gains over the best kicking option |
+| `first_down_prob` | conversion probability from the distribution |
+| `wp_succeed`, `wp_fail` | WP after converting / failing |
+| `fourth_down_recommendation` | the call |
+
+```{r fourth-down, eval=FALSE}
+library(cfbfastR)
+library(dplyr)
+
+pbp <- cfbfastR::load_cfb_pbp(2025)
+
+pbp |>
+  dplyr::filter(down == 4, !is.na(go_boost)) |>
+  dplyr::select(pos_team, distance, yards_to_goal, go_wp, fg_wp, punt_wp,
+                go_boost, first_down_prob, fourth_down_recommendation) |>
+  dplyr::arrange(dplyr::desc(go_boost)) |>
+  dplyr::slice_head(n = 20)
+```
+
+Sorting by `go_boost` finds the fourth downs where going for it was most clearly
+right — and, sorted the other way, the punts that cost the most.
+
+As with the two-point surface, **`go_boost` is more useful than the
+recommendation**: a 0.001 edge and a 0.08 edge are different decisions, and only
+the magnitude distinguishes them.
+
+## QBR
+
+A regression (`reg:squarederror`) on ten features, all of which are already EPA
+components: `qbr_epa`, `sack_epa`, `pass_epa`, `rush_epa`, `pen_epa`, plus
+`spread` and the one-hot era.
+
+This is worth being clear about, because QBR is often described as a black box.
+Here it is not a new measurement of anything — it is **a re-scaling of EPA
+components onto the 0–100 scale people recognise**, fit to reproduce the
+published QBR values. Everything it knows, it knows from EPA. If you want to
+understand why a quarterback's QBR is what it is, look at his EPA splits; there
+is nothing else in there.
+
+## Everything degrades to `NA`
+
+A design decision worth knowing about: none of these surfaces fail the pipeline.
+If a model artifact cannot be fetched, or `arrow` is missing, or the punt table
+is unavailable, or the game has no pre-game line, the columns are added as `NA`
+rather than the stage erroring.
+
+This means **you must check for `NA` rather than assuming a column is
+populated** — particularly `vegas_wp` and the two decision surfaces, which need
+a spread. The upside is that a network problem degrades your play-by-play instead
+of destroying it.
+
+```{r na-check, eval=FALSE}
+pbp |>
+  dplyr::summarise(dplyr::across(
+    c(EPA, wpa, vegas_wp, cpoe, xpass, go_boost),
+    ~ mean(is.na(.x))
+  ))
+```
+
+## Seeing it applied
+
+[Game on Paper](https://gameonpaper.com) surfaces most of this per game: the win
+probability chart, per-play EPA, and fourth-down decision context. Its
+[glossary](https://gameonpaper.com/glossary) defines the derived metrics in the
+same terms used here.
+
+## Frequently asked
+
+**What is CPOE in college football?**
+Completion percentage over expected — the gap between a passer's actual
+completions and what the situation predicted, in percentage points. It separates
+accuracy from difficulty of situation.
+
+**What is pass rate over expected (`pass_oe`)?**
+How much more often a team passes than its down, distance, score and clock
+suggest. It measures aggression, not effectiveness.
+
+**How accurate is the college field goal model?**
+It gives about 81% at 34 yards and 54% at 50. It has no kicker, weather or
+altitude input, and it flattens beyond roughly 57 yards where data runs out.
+
+**Should I trust `fourth_down_recommendation`?**
+Use `go_boost` instead. The recommendation has no margin, so it treats a
+0.0001 edge as a decision.
+
+## The series
+
+1. [Expected points: how the model works](college-football-expected-points-model-fundamentals-part-i.html)
+2. [How the model is built](college-football-expected-points-model-fundamentals-part-ii.html)
+3. [A history of expected points models](college-football-expected-points-model-fundamentals-part-iii.html)
+4. [What is EPA?](college-football-expected-points-model-fundamentals-part-iv.html)
+5. [Win probability, WPA and `vegas_wp`](college-football-expected-points-model-fundamentals-part-v.html)
+6. CPOE, xpass, field goals and fourth downs — this article
+
+## Data and artifacts
+
+- **Models** — [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts)
+- **Season play-by-play** — [`cfbfastR-data`](https://github.com/sportsdataverse/cfbfastR-data)
+- **Source** — [`cfbfastR`](https://github.com/sportsdataverse/cfbfastR) · [`sportsdataverse-py`](https://github.com/sportsdataverse/sportsdataverse-py) · [`cfb4th`](https://github.com/sportsdataverse/cfb4th)
+- **Applied, live** — [Game on Paper](https://gameonpaper.com)
+- **Raw API** — [CollegeFootballData.com](https://collegefootballdata.com), courtesy of [@CFB_data](https://x.com/CFB_data)
+
+## Citation
+
+```
+Gilani, S., Easwaran, A., Lee, J., and Hess, E. (2026). cfbfastR: Access College
+Football Play by Play Data. R package version 3.0.0.9000.
+https://cfbfastr.sportsdataverse.org
+```
+
+Authors, contributors and related SportsDataverse packages are listed on the
+[package home page](../index.html).
+
+```{r cleanup, include=FALSE}
+options(old)
+```


### PR DESCRIPTION
## Why

The EP Model Fundamentals series documented a model the package no longer ships.

Part I said "the multinomial logistic regression model calculates…" and Part II's
entire arc motivated arriving at multinomial logistic regression. Since #139 the
package scores with the XGBoost artifact from the `cfb_model_artifacts` bundle.
Issue #5 is the tell — `predict.nnet(): missing values in 'x'` — the retired model
was `nnet::multinom`, exactly what Part II taught readers to build. Part III closed
with the same claim, and Part II promised a "Part 4" that was never written.

## What

The series is now six articles, and finished.

| | |
|---|---|
| **I** | Expected points: what the model predicts, and the field-position curve |
| **II** | How it is built — and why 96 variables became 8 features |
| **III** | History: Carter 1970 → CMU/nflscrapR → the shared bundle |
| **IV** | *(new)* What is EPA? |
| **V** | *(new)* Win probability, WPA and `vegas_wp` |
| **VI** | *(new)* CPOE, xpass, FG, two-point, fourth down, QBR |

The model's evolution is carried explicitly rather than silently overwritten, and
the CRAN `3.0.0` vs GitHub `3.0.0.9000` fork is stated up front — the two
generations give different EPA for the same play.

## Reproducible, not asserted

Every figure is computed from the public bundle. Doing that caught **four** wrong
claims, three inherited and one of my own drafting:

| Claim | Actual |
|---|---|
| EP passes +3 around the opponent's 30–39 | opponent's **44** |
| 2nd→3rd gap "roughly double" 1st→2nd | **1.4×** (0.93 vs 0.65) |
| 3rd→4th gap narrows around the opponent's 25 | narrows steadily from the **40** |
| `spread_time` decays to 13.5% by halftime, so the spread's influence does too | the **feature** does; **55–80% of its influence** survives |

That last one is the important one. `spread_time` is an input, and the model's
response to it is learned and non-linear — it reacts more steeply as the input
shrinks. Feature magnitude is not influence.

## Limitations found by scoring the models

Documented in the articles rather than left for a user to discover:

- **The two-point model returns 0.578 flat** across every score margin, against
  real college rates near 45%. Confirms the `NEWS` caveat, and is why
  `two_pt_wp_diff` should be read instead of `two_pt_recommendation`.
- **The FG curve is constant at 0.366 beyond 60 yards** — out of training data,
  extrapolating flat. Anything past ~57 yards is not a real estimate.
- **`vegas_wp` is unstable late with small lines.** The `vegas_wp − wp` gap is
  non-monotonic and *changes sign* for a +7 line through Q4 (−15% at 10:00), and
  is unusable for +3 from the end of Q1. Tree behaviour where `|spread_time|` has
  decayed to a few tenths of a point.
- **An era-encoding trap:** `xpass` uses an *ordinal* era cutting at
  2006/2013/**2017**; FG, two-point and QBR use *one-hot* `era0..era3` cutting at
  2006/2013/**2020**. Different encodings and different cutpoints in one bundle.

## Verification

- All six articles render under pkgdown's `self_contained = FALSE` mode.
- All 19 vignettes indexed in `_pkgdown.yml` — no gap, no orphans.
- Parts IV–VI registered in **both** the navbar and the articles contents, grouped
  into a new "The Expected Points Model" section.

Code chunks are `eval=FALSE`: runnable against the public bundle, no API key, and
no docs build made dependent on the network.

Note: `rmarkdown::render()` with the default `self_contained = TRUE` fails on Part
III while embedding its imgur figures — **on `main` as well as here**, and because
imgur returns 429 to the build host rather than 404. Does not affect pkgdown.

## Follow-ups (not in this PR)

- Vendor the imgur / third-party figures into `cfbfastR-data`
- `canonical` + JSON-LD on the pkgdown site; the articles index has no meta description
- Consider whether the two-point model warrants a retrain given the 0.578 flat output

## Summary by Sourcery

Refresh the Expected Points documentation series to match the shipped model and complete it with coverage of EPA, win probability, and related football metrics.

New Features:
- Add three articles covering EPA, win probability and related metrics, and advanced model outputs including CPOE, xpass, field goals, two-point plays, fourth downs, and QBR.

Bug Fixes:
- Refresh the existing expected-points articles to describe the shipped XGBoost model and correct previously inaccurate model behavior claims.

Enhancements:
- Reorganize the six-part Expected Points series into its own pkgdown article section and navbar group with improved navigation and visual separation.
- Document reproducible model behavior, limitations, model evolution, and differences between CRAN and development versions.

Documentation:
- Complete and update the Expected Points Model Fundamentals documentation series with reproducible explanations of the model, EPA, win probability, and related metrics.

Tests:
- Verify that all six articles render under pkgdown, and that all indexed vignettes are registered without gaps or orphaned entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized navigation with a dedicated “The Expected Points Model” section covering six articles.
  * Updated Parts I–III with current model explanations, history, examples, artifacts, limitations, and usage guidance.
  * Added Part IV on college football EPA, including calculations, sign conventions, benchmarks, examples, and limitations.
  * Added Part V on win probability and WPA.
  * Added Part VI on derived models, including CPOE, pass rate, field goals, fourth-down decisions, and QBR.
* **Style**
  * Improved visual separation between article groups on the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->