### PR TITLE
fix(http): raise the CFBD retry budget so a throttle stops looking like no data

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -247,9 +247,14 @@ rbindlist_with_attrs <- function(dflist){
 }
 
 # Request Functions ----
+# build_req() is split out from get_req() so the retry/timeout policy can be
+# asserted in a test without performing a request (see
+# tests/testthat/test-utils_request_policy.R). get_req() remains the only entry
+# point callers use. Deliberately kept title-free so roxygen generates no .Rd
+# for an internal helper.
 #' @keywords Internal
 #' @importFrom httr2 request req_headers req_timeout req_retry req_error req_perform req_proxy
-get_req <- function(full_url, proxy = NULL) {
+build_req <- function(full_url, proxy = NULL) {
   req <- httr2::request(full_url) |>
     httr2::req_headers(Authorization = paste("Bearer", cfbd_key())) |>
     httr2::req_timeout(60)
@@ -280,13 +285,37 @@ get_req <- function(full_url, proxy = NULL) {
     }
   }
 
+  # Retry budget. httr2 retries 429/503 by default (`retry_is_transient`) and
+  # honours a `Retry-After` header when the server sends one, falling back to
+  # `backoff` when it does not.
+  #
+  # The previous budget -- 3 tries, ~1-9s of backoff -- is enough for an
+  # incidental 429 but not for sustained throttling, which is what a parallel
+  # caller produces. When it ran out, `req_error(is_error = ~FALSE)` handed the
+  # still-429 response back and `check_status()` turned it into a plain error,
+  # which every cfbd_*() tryCatch reports as "no data available". A throttle
+  # then looks exactly like an empty result. That is how cfbfastR_cfb_pbp
+  # published nothing from 2026-07-01 onward while its job stayed green:
+  # `cfbd_play_stats_player()` 429'd 63 times in one run, `sack_player_id`
+  # never materialised, and the downstream join aborted the whole script.
+  #
+  # `max_seconds` bounds the total wait so a hard-down API still fails in
+  # bounded time rather than hanging a caller for max_tries * backoff.
+  #
+  # Note this is the production path only -- tests already slow themselves via
+  # the `get_req()` wrapper in tests/testthat/setup-cfbd-throttle.R.
   req |>
     httr2::req_retry(
-      max_tries = 3,
-      backoff   = function(i) stats::runif(1, 0.5, 1.5) * (2 ^ i)
+      max_tries   = 6,
+      max_seconds = 120,
+      backoff     = function(i) stats::runif(1, 0.5, 1.5) * (2 ^ i)
     ) |>
-    httr2::req_error(is_error = function(resp) FALSE) |>
-    httr2::req_perform()
+    httr2::req_error(is_error = function(resp) FALSE)
+}
+
+#' @keywords Internal
+get_req <- function(full_url, proxy = NULL) {
+  httr2::req_perform(build_req(full_url, proxy = proxy))
 }
 
 #' Drop NULL entries from a list (internal)

--- a/tests/testthat/test-utils_request_policy.R
+++ b/tests/testthat/test-utils_request_policy.R
@@ -1,0 +1,39 @@
+test_that("build_req() carries a retry budget that survives sustained CFBD throttling", {
+  # Offline by design: build_req() only constructs the request, and cfbd_key()
+  # returns NA rather than erroring when CFBD_API_KEY is unset, so this needs
+  # neither network nor credentials.
+  req <- cfbfastR:::build_req("https://api.collegefootballdata.com/games")
+
+  # httr2 already retries 429/503 (retry_is_transient) and honours a
+  # Retry-After header; what this package controls is the budget. The previous
+  # 3 tries / ~1-9s of backoff covered an incidental 429 but not the sustained
+  # throttling a parallel caller produces -- when it ran out, check_status()
+  # turned the surviving 429 into an error that every cfbd_*() tryCatch reports
+  # as "no data available", making a throttle indistinguishable from an empty
+  # result.
+  expect_gte(req$policies$retry_max_tries, 6L)
+  expect_gte(req$policies$retry_max_wait, 120)
+
+  # A backoff must still exist for servers that send no Retry-After header.
+  expect_type(req$policies$retry_backoff, "closure")
+  expect_true(is.finite(req$policies$retry_backoff(1)))
+})
+
+test_that("build_req() leaves HTTP status handling to check_status()", {
+  req <- cfbfastR:::build_req("https://api.collegefootballdata.com/games")
+
+  # req_error(is_error = ~FALSE) is deliberate: the response is handed back so
+  # check_status() can raise the "The CFBD API returned HTTP ..." message the
+  # cfbd_*() family reports. If this ever flips to TRUE, httr2 would abort
+  # first and that message would never be produced.
+  expect_type(req$policies$error_is_error, "closure")
+  expect_false(req$policies$error_is_error(
+    structure(list(status_code = 429L), class = "httr2_response")
+  ))
+})
+
+# No test asserts that get_req() delegates to build_req(): setup-cfbd-throttle.R
+# hot-swaps get_req() in the cfbfastR namespace for the whole test session, so
+# anything inspecting it here sees the throttle wrapper rather than the package
+# function. build_req() is not swapped, which is why the policy assertions above
+# target it directly.


### PR DESCRIPTION
## Why

`cfbfastR_cfb_pbp` published nothing from **2026-07-01** onward — no `play_by_play_2026` asset at all — while the `cfbfastR-data` job that builds it reported **success** every run.

In one run, `cfbd_play_stats_player()` hit **HTTP 429 sixty-three times**. `sack_player_id` never materialised, and the roster join in `week.R:349` aborted the script **628 lines before** the release upload at `week.R:977`.

## What was actually wrong

httr2 was already doing the right things — `retry_is_transient()` retries 429/503 by default, and `retry_after()` honours a `Retry-After` header when the server sends one, falling back to our `backoff` when it doesn't. I checked both in the installed httr2 (1.2.3) rather than assuming, because my first hypothesis — that `req_error(is_error = ~FALSE)` was disabling retries — was **wrong**: the `is_error()` in `retry_is_transient()` is rlang's "is this an error condition object", not an HTTP-status check.

The only thing wrong was the **budget**: `max_tries = 3` with ~1–9s of backoff. That covers an incidental 429, not the sustained throttling a parallel caller produces.

When the budget ran out, `req_error(is_error = ~FALSE)` handed the still-429 response back, `check_status()` raised `The CFBD API returned HTTP 429`, and every `cfbd_*()` `tryCatch` reported it as `"... or no data available"`. **A throttle became indistinguishable from an empty result** — which is what made this expensive to diagnose rather than expensive to fix.

Worth noting the repo already knew about this: `tests/testthat/setup-cfbd-throttle.R` exists precisely because back-to-back calls trip the CFBD limit. The test-time workaround was in place; the production resilience gap was not.

## The change

`max_tries = 6`, `max_seconds = 120`. The cap matters — without it a hard-down API hangs a caller for the full `tries × backoff` product. **All 28 callers of `get_req()` inherit this.**

Also split `build_req()` out of `get_req()`. `get_req()` performed immediately, so the policy couldn't be asserted without network; `build_req()` now returns the request and `get_req()` is a one-line performer over it. The signature is unchanged, so `setup-cfbd-throttle.R` keeps working.

## Verification

- **6/6 assertions pass offline** — `build_req()` needs neither network nor `CFBD_API_KEY` (`cfbd_key()` returns `NA` when unset), so no skip guards are required.
- **The test is a real guard**: the same assertions fail against the old 3-try / no-`max_wait` policy.
- No test asserts that `get_req()` delegates to `build_req()`, and the file says why: `setup-cfbd-throttle.R` hot-swaps `get_req()` in the namespace for the whole session, so anything inspecting it in-suite sees the throttle wrapper. I wrote that assertion first, watched it fail for exactly that reason, and removed it.

## Generated files deliberately untouched

`build_req()` is title-free in roxygen so no `.Rd` is generated for an internal helper — verified `roxygenise()` produces no `man/build_req.Rd`.

Nothing else is regenerated on purpose: the committed docs predate the local roxygen, so `roxygenise()` rewrites **~150 unrelated `man/*.Rd`** plus a hand-formatted multi-line `NAMESPACE`. That churn is excluded rather than smuggled into this PR. Worth a separate housekeeping pass to decide whether to re-baseline the docs.

## Scope

This is the package half. The companion change lowering `future::plan(workers = ...)` in `cfbfastR-data`'s `week.R` reduces the request rate that provokes the throttle in the first place; retries alone are the resilience, not the cure.

## Summary by Sourcery

Improve CFBD request resilience by extending bounded retries for sustained API throttling and adding offline coverage for the request policy.

Bug Fixes:
- Increase the CFBD request retry budget to better withstand sustained HTTP 429/503 throttling while preserving bounded failure time.
- Prevent throttled responses from being prematurely treated as indistinguishable from empty data by retaining existing HTTP status handling.

Enhancements:
- Separate request construction from request execution so retry and timeout policies can be tested without network access.

Tests:
- Add offline tests covering the retry budget, backoff configuration, and HTTP status handling policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of throttled requests with up to six retry attempts and a maximum wait of 120 seconds.
  - Preserved custom error handling for rate-limited responses.
  - Added more reliable backoff behavior when servers do not provide retry timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->