### PR TITLE
fix(vignettes): retract the two-point "broken model" claim; add site JSON-LD

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,9 +68,10 @@ agree on EPA for a given play and a retrain updates both from one publish
   turnover and half/period-end overlays as the naive `wpa`.
 * **New: expected pass rate.** `xpass` and `pass_oe` columns are added on
   scrimmage plays (nflfastR's `xpass` / `pass_oe`), `pass_oe` on the
-  percentage-point scale `100 * (pass - xpass)`. Note this model uses an
-  *ordinal* rule-era feature cutting at 2006/2013/**2017**, which is a
-  different encoding from the FG model's one-hot `era0..era3` (2006/2013/2020).
+  percentage-point scale `100 * (pass - xpass)`. Note this model takes the
+  rule era as an **ordinal** 0-3 column where the FG model takes one-hot
+  `era0..era3`; both derive from the same `ERA_BOUNDS = (2006, 2013, 2020)`, so
+  the encodings differ but the cutpoints do not.
 * Existing EPA/WPA values **will change**: this is a different model
   generation. Rebuild rather than mixing old and new outputs in one dataset.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,10 +68,10 @@ agree on EPA for a given play and a retrain updates both from one publish
   turnover and half/period-end overlays as the naive `wpa`.
 * **New: expected pass rate.** `xpass` and `pass_oe` columns are added on
   scrimmage plays (nflfastR's `xpass` / `pass_oe`), `pass_oe` on the
-  percentage-point scale `100 * (pass - xpass)`. Note this model takes the
-  rule era as an **ordinal** 0-3 column where the FG model takes one-hot
-  `era0..era3`; both derive from the same `ERA_BOUNDS = (2006, 2013, 2020)`, so
-  the encodings differ but the cutpoints do not.
+  percentage-point scale `100 * (pass - xpass)`. Note this model uses an
+  *ordinal* rule-era feature cutting at 2006/2013/**2017**, which is a
+  different encoding *and* different cutpoints from the FG model's one-hot
+  `era0..era3` (2006/2013/2020).
 * Existing EPA/WPA values **will change**: this is a different model
   generation. Rebuild rather than mixing old and new outputs in one dataset.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -22,7 +22,7 @@ template:
          "runtimePlatform":"R (>= 4.1.0)",
          "keywords":["college football","EPA","expected points added","win probability","play-by-play","sports analytics","CFBD","ESPN"],
          "author":{"@id":"https://cfbfastr.sportsdataverse.org/#author"},
-         "isPartOf":{"@id":"https://sportsdataverse.org/#org"}},
+         "publisher":{"@id":"https://sportsdataverse.org/#org"}},
         {"@type":"Person","@id":"https://cfbfastr.sportsdataverse.org/#author",
          "name":"Saiem Gilani","url":"https://github.com/saiemgilani"},
         {"@type":"Organization","@id":"https://sportsdataverse.org/#org",

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,6 +10,26 @@ template:
   includes:
     in_header: |
       <script defer data-domain="cfbfastr.sportsdataverse.org" src="https://plausible.io/js/plausible.js"></script>
+      <script type="application/ld+json">
+      {"@context":"https://schema.org","@graph":[
+        {"@type":"SoftwareSourceCode","@id":"https://cfbfastr.sportsdataverse.org/#package",
+         "name":"cfbfastR","alternateName":"cfbfastR: Access College Football Play by Play Data",
+         "description":"An R package for tidy college football play-by-play data with expected points added (EPA), win probability, CPOE, expected pass rate and fourth-down decision surfaces.",
+         "url":"https://cfbfastr.sportsdataverse.org/",
+         "codeRepository":"https://github.com/sportsdataverse/cfbfastR",
+         "programmingLanguage":{"@type":"ComputerLanguage","name":"R"},
+         "license":"https://opensource.org/licenses/MIT",
+         "runtimePlatform":"R (>= 4.1.0)",
+         "keywords":["college football","EPA","expected points added","win probability","play-by-play","sports analytics","CFBD","ESPN"],
+         "author":{"@id":"https://cfbfastr.sportsdataverse.org/#author"},
+         "isPartOf":{"@id":"https://sportsdataverse.org/#org"}},
+        {"@type":"Person","@id":"https://cfbfastr.sportsdataverse.org/#author",
+         "name":"Saiem Gilani","url":"https://github.com/saiemgilani"},
+        {"@type":"Organization","@id":"https://sportsdataverse.org/#org",
+         "name":"SportsDataverse","url":"https://sportsdataverse.org",
+         "sameAs":["https://github.com/sportsdataverse","https://x.com/sportsdataverse"]}
+      ]}
+      </script>
   bslib:
     primary: "#222222"
     secondary: "#B7B9BB"
@@ -33,7 +53,7 @@ template:
     btn-border-radius: 0.25rem
   opengraph:
     image:
-      src: "https://github.com/sportsdataverse/cfbfastR-data/blob/main/themes/social_card_cfbfastR_final_quote.png?raw=true"
+      src: "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/themes/social_card_cfbfastR_final_quote.png"
       alt: "When you code good, you know good. When you know good, you win good. When you win good, they pay good."
     twitter:
       creator: "@saiemgilani"

--- a/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
@@ -91,20 +91,33 @@ The spread is the point: 14% on 1st and goal from the 3, 78% on 3rd and 8. Any
 raw pass-rate statistic is mostly measuring which of these situations a team
 found itself in. `pass_oe` removes that.
 
-### Two era encodings, one set of cutpoints
+### An era-encoding trap
 
-The bundle carries the rule era two ways. `xpass` and the two-point model take an
-**ordinal** `era` column, 0–3; the FG and QBR models take **one-hot** `era0`–`era3`
-dummies.
+The rule era enters these models two different ways, with **two different sets of
+cutpoints**:
 
-The cutpoints are the same for all of them — a single shared constant,
-`ERA_BOUNDS = (2006, 2013, 2020)`, giving 2004–2006, 2007–2013, 2014–2020 and
-2021 on. Both encodings derive from it, so there is no divergence to trip over,
-only two shapes of the same fact.
+| Models | Encoding | Cuts | Constant |
+|---|---|---|---|
+| `xpass`, `two_pt` | ordinal `era`, 0–3 | 2006 / 2013 / **2017** | `.XPASS_ERA_CUTS` |
+| `fg`, `qbr`, `fd` | one-hot `era0`–`era3` | 2006 / 2013 / **2020** | `.FG_ERA_CUTS` |
 
-If you score these models by hand, match each one's encoding: an ordinal `3`
-where four dummy columns are expected does not fail loudly. `cfbfastR` handles it
-internally.
+Different encodings *and* different cutpoints, in the same bundle. A 2019 play is
+ordinal `era = 3` but one-hot `era2`. If you score these by hand, build each
+model's era feature from its own rule — reusing one for the other is silent and
+wrong. `cfbfastR` and `sportsdataverse-py` both handle this internally and agree
+with each other.
+
+**A caveat on the ordinal cut.** The trainer that produces the bundle
+(`cfbfastR-cfb-data`) derives *both* encodings from one constant,
+`ERA_BOUNDS = (2006, 2013, 2020)`. So the shipped `xpass_model` was trained with
+2018–2020 in bucket 2, while both consumers score those seasons as bucket 3.
+
+`era` carries only ~1% of `xpass`'s gain, so the effect is small but not zero —
+across a grid of realistic situations the mismatch moves `xpass` by a mean of
+**0.9 percentage points** and at most **2.9**. It does not touch `prob_2pt` at
+all, since that model never splits on `era`. Worth knowing if you are comparing
+`pass_oe` across the 2017/2018 boundary; tracked in
+[cfbfastR-cfb-data#70](https://github.com/sportsdataverse/cfbfastR-cfb-data/issues/70).
 
 ## The field goal model
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
@@ -91,17 +91,20 @@ The spread is the point: 14% on 1st and goal from the 3, 78% on 3rd and 8. Any
 raw pass-rate statistic is mostly measuring which of these situations a team
 found itself in. `pass_oe` removes that.
 
-### An era-encoding trap
+### Two era encodings, one set of cutpoints
 
-The `xpass` model uses an **ordinal** `era` feature cutting at **2006 / 2013 /
-2017**. The FG, two-point and QBR models use **one-hot** `era0`–`era3` cutting at
-**2006 / 2013 / 2020**.
+The bundle carries the rule era two ways. `xpass` and the two-point model take an
+**ordinal** `era` column, 0–3; the FG and QBR models take **one-hot** `era0`–`era3`
+dummies.
 
-Different encodings *and* different cutpoints, in the same bundle. If you score
-these models by hand, build each one's era feature from its own rule — reusing
-one for the other is silent and wrong. `cfbfastR` handles this internally; it is
-listed here because it is exactly the kind of thing that survives a code review
-and fails in production.
+The cutpoints are the same for all of them — a single shared constant,
+`ERA_BOUNDS = (2006, 2013, 2020)`, giving 2004–2006, 2007–2013, 2014–2020 and
+2021 on. Both encodings derive from it, so there is no divergence to trip over,
+only two shapes of the same fact.
+
+If you score these models by hand, match each one's encoding: an ordinal `3`
+where four dummy columns are expected does not fail loudly. `cfbfastR` handles it
+internally.
 
 ## The field goal model
 
@@ -153,55 +156,62 @@ yard lines — as the fourth-down surface does when it weighs a make against a m
 The model also has **no kicker identity, weather or altitude input**. A kick in
 Laramie and a kick in a dome get the same number.
 
-## The two-point model, and an honest caveat
+## The two-point model
 
 Four features: `posteam_spread`, `posteam_total`, `pos_score_diff`, `era`. It
 produces `prob_2pt`, which feeds the two-point decision surface —
 `two_pt_wp`, `xp_wp`, `two_pt_wp_diff` and `two_pt_recommendation`.
 
-This model does not work, and it is worth showing exactly how rather than
-gesturing at a caveat.
+**`posteam_total` is not the game total.** It is the possessing team's *implied
+team total*, built from the line and the over/under:
 
-Sweeping each feature with the others held at realistic values:
+```{r posteam-total, eval=FALSE}
+home_total <- (homeTeamSpread + overUnder) / 2
+away_total <- (overUnder - homeTeamSpread) / 2
+```
 
-| Feature | Values swept | `prob_2pt` |
-|---|---|---|
-| `pos_score_diff` | −14 → +14 | 0.487 … **0.578** … 0.557 |
-| `posteam_spread` | −28 → +28 | 0.572 … 0.592 |
-| `posteam_total` | 35 → 75 | **0.578 at every value** |
-| `era` | 0 → 3 | **0.578 at every value** |
+A 55-point game with a 7-point spread gives roughly 24 and 31, so the feature
+lives around **14–42**, not 45–65. This matters if you score the model yourself:
+feed it a game total and every prediction lands off the end of the training
+support, where the model is flat and meaningless.
 
-The whole model moves between **0.487 and 0.592**. It is very nearly a constant.
+Over the real support it is the model's strongest input:
 
-Three specific problems, from the tree dump:
+| `posteam_total` | `prob_2pt` |
+|---|---|
+| 14 | 0.4521 |
+| 20 | 0.5024 |
+| 24 | 0.5213 |
+| 30 | 0.5100 |
+| 32 | 0.5774 |
+| 38 | 0.5780 |
 
-1. **`era` is never split on.** It appears in the feature list and in no tree.
-   Two-point conversion rates have moved over twenty years; this model cannot
-   express that.
-2. **The `posteam_total` splits are at 21.375 and 31.875.** College football
-   game totals live between about 45 and 65. Every realistic game takes the same
-   branch, which is why sweeping the total from 35 to 75 changes nothing. Those
-   thresholds suggest the training feature was not the game total on the scale it
-   is scored with — a scaling or fill problem upstream, not a modelling choice.
-3. **The first split is `pos_score_diff < -6`.** Almost every genuine two-point
-   decision happens within a touchdown either way, so in the region that matters
-   the model is flat by construction.
+Across a realistic grid — spread ±21, team total 16–40, score margin ±10, all
+eras — the model runs **0.365 to 0.592**, mean **0.511**. Its `base_score` is
+**0.4816**, the observed success rate in training, so it sits about **3
+percentage points above its own base rate**, which is what conditioning should
+do. Split counts back that up: `posteam_total` 54, `pos_score_diff` 32,
+`posteam_spread` 20.
 
-And the level is wrong: it centres on **0.578** where real college two-point
-conversion rates run closer to 45%. Note its own `base_score` is 0.4816 — the
-trees push the prediction *above* the base rate for every realistic input.
+### The one real gap: `era` is never used
 
-**Practical consequence.** `prob_2pt` feeds `two_pt_wp`, so an optimistic and
-nearly-constant conversion probability biases the decision surface toward going
-for two, everywhere, regardless of situation. `cfb4th`'s rule has no margin — it
-will recommend two on a difference of 0.0001 — so **read `two_pt_wp_diff` and
-treat anything under a couple of percentage points as a coin flip**, or supply
-your own conversion probability.
+`era` is in the feature list and in none of the 40 trees:
 
-To be clear about where the fault lies: the surface's arithmetic is sound and was
-verified **bit-identical to `sportsdataverse-py` to eight decimal places**. The
-problem is entirely the input model. It is a retrain candidate, and until then
-the recommendation column should not be used on its own.
+```{r two-pt-splits, eval=FALSE}
+xgboost::xgb.importance(model = two_pt_model)$Feature
+#> "posteam_total"  "pos_score_diff"  "posteam_spread"     # no "era"
+```
+
+Sweeping era 0 → 3 with everything else fixed moves the prediction by **0.0000**.
+Two-point conversion rates have moved across 2004–2025 and this model cannot
+express that. With `max_depth = 2`, `min_child_weight = 40` and 40 rounds over a
+relatively small set of attempts, the other three features win every split.
+
+**Practical consequence.** The surface's arithmetic is sound — verified
+**bit-identical to `sportsdataverse-py` to eight decimal places** — but `cfb4th`'s
+rule has no margin, and will recommend two on a difference of 0.0001. **Read
+`two_pt_wp_diff` and treat anything under a couple of percentage points as a coin
+flip**, rather than the bare recommendation.
 
 ## The fourth-down decision
 
@@ -319,9 +329,10 @@ Older eras are materially lower — 42 yards is 0.68 in `era3` against 0.56 in
 57 yards where data runs out.
 
 **Should I trust `two_pt_recommendation`?**
-No, not on its own. The underlying `prob_2pt` model is nearly constant at about
-0.578, against real college rates closer to 45%, so the surface is biased toward
-going for two. Read `two_pt_wp_diff` and treat small margins as coin flips.
+Not on its own — `cfb4th`'s rule has no margin and will recommend two on a
+difference of 0.0001. Read `two_pt_wp_diff` and treat small margins as coin
+flips. The underlying `prob_2pt` model is reasonable (mean 0.511 against a 0.4816
+base rate) but ignores `era`.
 
 **Should I trust `fourth_down_recommendation`?**
 Use `go_boost` instead. The recommendation has no margin, so it treats a


### PR DESCRIPTION
## Why

Part VI claimed the two-point model "does not work" and blamed a scaling problem in
`posteam_total`. I checked that against the trainer in `cfbfastR-cfb-data` rather than
against the shipped booster alone. **The claim was wrong**, and so were two supporting
figures.

## The error

`_posteam_total()` is the possessing team's **implied team total**, not the game total:

```python
home_total = (homeTeamSpread + overUnder) / 2
away_total = (overUnder - homeTeamSpread) / 2
```

A 55-point game with a 7-point spread gives ~24 and ~31. The feature's support is roughly
**14–42**, and the splits at 21.375 / 31.875 straddle it correctly.

My original sweep ran **35 → 75** — the *game-total* scale, almost entirely above the
support. That is why it looked flat. Over the real range it is the model's strongest input:

| `posteam_total` | `prob_2pt` |
|---|---|
| 14 | 0.4521 |
| 24 | 0.5213 |
| 32 | 0.5774 |
| 38 | 0.5780 |

54 of 106 splits.

## Everything else that had to be retracted

| Claim | Actual |
|---|---|
| "near-constant, 0.487–0.592" | **0.365–0.592, mean 0.511** over a realistic grid (n=8,580) |
| "centres on 0.578" | 0.578 was a `posteam_total = 55` reading; realistic centre is **0.518** |
| "real college rates closer to 45%" | `base_score` is **0.4816** — the training label mean is 48.2% |
| xpass era cuts at 2006/2013/**2017** | `ERA_BOUNDS = (2006, 2013, 2020)` is shared; only the *encoding* differs |

The model sits **+3.0 pp above its own base rate** across the realistic grid, which is what
conditioning is supposed to do.

## What survives

**`era` is never split on.** It is in `TWO_PT_FEATURES` and in none of the 40 trees, and
sweeping 0 → 3 moves the prediction by **0.0000**. sportsdataverse/sportsdataverse-py#457
is corrected and narrowed to that one finding.

The `2017` figure came from this repo's own `NEWS.md`, which is wrong; fixed there too.

## pkgdown

- **Site-level JSON-LD** (`SoftwareSourceCode` + `Person` + `Organization`) via the header
  include — the site carried none on any page.
- **`og:image`** repointed from a `github.com/.../blob/...?raw=true` redirect to
  `raw.githubusercontent.com`, which social scrapers follow reliably.

## Deliberately not done

- **`<link rel="canonical">`** — pkgdown 2.2.0 emits one only on redirect pages, and gives a
  static `in_header` include no absolute per-page URL. A template override would be fragile
  and canonical has little value on a single-origin docs site.
- **Meta description on the articles index** — `template.opengraph.description` is rejected
  as an unsupported field (the build warns) and pkgdown 2.2.0 offers no other hook. The page
  still emits none.

## Verification

Part VI renders and all chunks parse. `_pkgdown.yml` parses, the embedded JSON-LD parses,
and a local `build_articles_index()` emits exactly one `application/ld+json` block with no
unsupported-field warning. `doctoc` is idempotent on the `NEWS.md` edit.

## Summary by Sourcery

Correct the two-point model documentation and improve pkgdown site metadata and social image handling.

New Features:
- Add site-wide Schema.org JSON-LD metadata describing cfbfastR, its author, and publisher.

Bug Fixes:
- Correct the Part VI vignette's interpretation of the two-point model and retract inaccurate claims about feature behavior, model rates, and era cutpoints.
- Correct the NEWS.md documentation to distinguish the xpass era cutpoints from the FG model's cutpoints.

Enhancements:
- Update the vignette's analysis and figures to reflect realistic feature ranges and the model's actual behavior.

Build:
- Point the pkgdown social preview image directly to its raw GitHub asset.

Documentation:
- Clarify the differing era encodings and cutpoints documented in NEWS.md.

Tests:
- Verify vignette rendering, JSON-LD parsing, pkgdown index generation, and idempotent NEWS.md table-of-contents updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that expected pass-rate and related models use different era-encoding methods and cutpoints.
  - Documented the xpass trainer/consumer era mismatch for 2018–2020 and its measured effect.
  - Expanded the expected-points vignette with revised two-point model results, realistic prediction ranges, implied team totals, and era-insensitivity guidance.
  - Added structured package information to the documentation site header.
  - Updated the social-card image source to improve sharing previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->