### PR TITLE
fix(pbp): score xpass/two_pt with the era cuts the models were trained on

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,20 @@ agree on EPA for a given play and a retrain updates both from one publish
   model reads positive `spread_time` as the team in possession being favoured.
   `vegas_wpa` and `vegas_wp_after` are derived alongside it, using the same
   turnover and half/period-end overlays as the naive `wpa`.
+* **Fix: `xpass` / `two_pt` scored 2018-2020 in the wrong rule era.** The
+  ordinal `era` column was cut at 2006/2013/**2017**, but the producer
+  (`cfbfastR-cfb-data`) derives BOTH era encodings from one
+  `ERA_BOUNDS = (2006, 2013, 2020)` and has never carried a 2017 cut -- so those
+  three seasons were scored as era 3 against models that trained them as era 2.
+  `era` takes 251 splits and ~1.1% of gain in `xpass_model`: across 630
+  realistic situations the mismatch moved `xpass` by a mean of 0.9pp and at most
+  2.9pp, inherited by `pass_oe` as a step at the 2017/2018 boundary. `prob_2pt`
+  was unaffected -- that model never splits on `era`. The 2017 figure traces to a
+  stale docstring on sdv-py's `cfb_two_point.py::_era`, whose code already read
+  the 2020 bounds. `.XPASS_ERA_CUTS` now equals `.FG_ERA_CUTS`; the two remain
+  separate constants because the ENCODINGS differ (one ordinal column vs four
+  one-hot dummies). See
+  [cfbfastR-cfb-data#70](https://github.com/sportsdataverse/cfbfastR-cfb-data/issues/70).
 * **New: expected pass rate.** `xpass` and `pass_oe` columns are added on
   scrimmage plays (nflfastR's `xpass` / `pass_oe`), `pass_oe` on the
   percentage-point scale `100 * (pass - xpass)`. Note this model uses an

--- a/R/pbp_model_artifacts.R
+++ b/R/pbp_model_artifacts.R
@@ -504,10 +504,10 @@ NULL
 #' supply.
 #'
 #' **These cuts (2006/2013/2020) are the ONE-HOT `era0..era3` cuts used by
-#' `fg_model` and `fd_model`.** sdv-py also carries a distinct *ordinal* `era`
-#' with cuts 2006/2013/**2017** for `xpass_model` / `two_pt_model`. The two are
-#' not interchangeable; conflating them silently mis-labels the 2018-2020
-#' seasons.
+#' `fg_model` and `fd_model`.** [.XPASS_ERA_CUTS] is the *ordinal* `era` for
+#' `xpass_model` / `two_pt_model`. Both now carry the same cutpoints -- the
+#' producer derives them from one constant -- but they are NOT interchangeable
+#' as features: one is a single 0-3 column, the other four dummies.
 #'
 #' @keywords internal
 #' @noRd
@@ -691,14 +691,21 @@ NULL
 #' Expected-pass feature contract and the ORDINAL rule-era cuts
 #'
 #' `.XPASS_ERA_CUTS` is the **ordinal** `era` used by `xpass_model` and
-#' `two_pt_model` -- cuts 2006/2013/**2017**, encoded 0/1/2/3 in one column.
-#' It is NOT [.FG_ERA_CUTS], the one-hot `era0..era3` set used by
-#' `fg_model`/`fd_model`, whose third cut is **2020**. The two disagree over
-#' 2018-2020, so they are deliberately separate constants.
+#' `two_pt_model`, encoded 0/1/2/3 in one column. [.FG_ERA_CUTS] is the
+#' **one-hot** `era0..era3` set used by `fg_model`/`fd_model`. The ENCODINGS
+#' differ; the cutpoints do not.
+#'
+#' These were 2006/2013/**2017** until it was checked against the producer.
+#' `cfbfastR-cfb-data` derives both encodings from one
+#' `ERA_BOUNDS = (2006, 2013, 2020)`, and has never carried a 2017 cut -- so
+#' 2018-2020 were being scored as era 3 against models that trained them as
+#' era 2. The 2017 figure came from a stale docstring on sdv-py's
+#' `cfb_two_point.py::_era`, whose CODE already read the 2020 bounds.
+#' See sportsdataverse/cfbfastR-cfb-data#70.
 #'
 #' @keywords internal
 #' @noRd
-.XPASS_ERA_CUTS <- c(2006, 2013, 2017)
+.XPASS_ERA_CUTS <- c(2006, 2013, 2020)
 
 #' @keywords internal
 #' @noRd
@@ -709,7 +716,7 @@ NULL
 
 #' Ordinal CFB rule era from season
 #'
-#' @return 0 (<=2006), 1 (<=2013), 2 (<=2017), 3 (later).
+#' @return 0 (<=2006), 1 (<=2013), 2 (<=2020), 3 (later).
 #' @keywords internal
 #' @noRd
 .cfb_era_ordinal <- function(season, n) {

--- a/tests/testthat/test-fg_model_artifacts.R
+++ b/tests/testthat/test-fg_model_artifacts.R
@@ -2,14 +2,14 @@
 ###
 ### Two traps here. (1) An absent season makes every era dummy 0 -- not a valid
 ### one-hot -- which shifts every field-goal probability without erroring.
-### (2) sdv-py carries TWO era definitions: the one-hot era0..era3 used by
-### fg_model/fd_model cuts at 2006/2013/2020, while the ORDINAL `era` used by
-### xpass/two_pt cuts at 2006/2013/2017. Conflating them mislabels 2018-2020.
+### (2) there are TWO era ENCODINGS: the one-hot era0..era3 used by
+### fg_model/fd_model, and the single ordinal `era` used by xpass/two_pt. Both
+### cut at 2006/2013/2020; conflating the SHAPES still mislabels every season.
 
 test_that("FG era cuts are the one-hot set, not the ordinal set", {
   expect_identical(.FG_ERA_CUTS, c(2006, 2013, 2020))
-  # 2018 is the season that distinguishes the two definitions: era2 under the
-  # one-hot cuts, but ordinal-era 3 under the 2017 cut.
+  # 2018 used to distinguish them, when the ordinal cut was wrongly 2017.
+  # It is bucket 2 under both now; the encodings still differ in shape.
   expect_equal(unname(.cfb_era_onehot(2018, 1)[1, ]), c(0, 0, 1, 0))
 })
 

--- a/tests/testthat/test-fourth-down.R
+++ b/tests/testthat/test-fourth-down.R
@@ -29,8 +29,8 @@ test_that("class 0 of the fourth-down model is a ten-yard LOSS", {
 })
 
 test_that("the fourth-down model uses the ONE-HOT era, not the ordinal one", {
-  # fd_model and fg_model take era0..era3 (cuts 2006/2013/2020); xpass and
-  # two_pt take a single ordinal era (2017 cut). 2018 separates them.
+  # fd_model and fg_model take era0..era3; xpass and two_pt take a single
+  # ordinal era. Same cuts (2006/2013/2020) since #70 -- different shape.
   expect_true(all(c("era0", "era1", "era2", "era3") %in% .FD_FEATURES))
   expect_equal(unname(.cfb_era_onehot(2018, 1)[1, ]), c(0, 0, 1, 0))
 })

--- a/tests/testthat/test-qbr.R
+++ b/tests/testthat/test-qbr.R
@@ -93,8 +93,8 @@ test_that("create_qbr uses the ONE-HOT era, not the ordinal one", {
   expect_equal(unname(unlist(out[1, c("era0", "era1", "era2", "era3")])),
                c(0, 0, 0, 1))
   pbp <- mk_pbp(); pbp$season <- 2018
-  # 2018 is exactly the season that separates the two encodings: era2 one-hot
-  # (2020 cut) but the ordinal era's post-2017 bucket.
+  # 2018 is bucket 2 under both encodings; it only diverged while the ordinal
+  # cut was wrongly 2017 (see cfbfastR-cfb-data#70).
   out18 <- create_qbr(pbp, qbr_model = NA)
   expect_equal(unname(unlist(out18[1, c("era0", "era1", "era2", "era3")])),
                c(0, 0, 1, 0))

--- a/tests/testthat/test-two_pt_artifacts.R
+++ b/tests/testthat/test-two_pt_artifacts.R
@@ -11,8 +11,9 @@
 test_that(".TWO_PT_FEATURES matches the bundle contract and uses ordinal era", {
   expect_identical(.TWO_PT_FEATURES,
                    c("posteam_spread", "posteam_total", "pos_score_diff", "era"))
-  # Ordinal era (2017 cut), like xpass -- not the FG model's one-hot set.
-  expect_equal(.cfb_era_ordinal(2018, 1), 3)
+  # A single ordinal era column, like xpass -- not the FG model's one-hot set.
+  # Same cuts as the one-hot set since #70; 2018 is bucket 2 under both.
+  expect_equal(.cfb_era_ordinal(2018, 1), 2)
 })
 
 test_that(".cfb_posteam_total splits the over/under by the spread", {

--- a/tests/testthat/test-xpass_model_artifacts.R
+++ b/tests/testthat/test-xpass_model_artifacts.R
@@ -3,8 +3,9 @@
 ### Two traps, both shared with models already in this PR:
 ###   * `pos_score_diff` is sourced from `pos_score_diff_start`, not the frame's
 ###     like-named column, which holds a different value.
-###   * the ORDINAL era here cuts at 2006/2013/2017, NOT the one-hot era0..era3
-###     cuts of 2006/2013/2020 used by the FG model.
+###   * the era here is a single ORDINAL 0-3 column, NOT the one-hot era0..era3
+###     set the FG model takes. Same cutpoints (2006/2013/2020, the producer
+###     derives both from one constant); different SHAPE.
 
 test_that(".XPASS_FEATURES matches the bundle contract", {
   expect_identical(
@@ -14,17 +15,20 @@ test_that(".XPASS_FEATURES matches the bundle contract", {
   )
 })
 
-test_that("the ordinal era is NOT the one-hot era set", {
-  expect_identical(.XPASS_ERA_CUTS, c(2006, 2013, 2017))
-  expect_false(identical(.XPASS_ERA_CUTS, .FG_ERA_CUTS))
-  # 2018-2020 is exactly where the two disagree: ordinal era 3, one-hot era2.
-  expect_equal(.cfb_era_ordinal(2018, 1), 3)
+test_that("the ordinal era shares the one-hot cutpoints but not its shape", {
+  # Both derive from the producer's single ERA_BOUNDS = (2006, 2013, 2020)
+  # (cfbfastR-cfb-data/model_training/constants.py), so the CUTS agree.
+  expect_identical(.XPASS_ERA_CUTS, c(2006, 2013, 2020))
+  expect_identical(.XPASS_ERA_CUTS, .FG_ERA_CUTS)
+  # 2018 was where a 2017 ordinal cut used to disagree: it scored era 3 against
+  # a model trained with it as era 2. Both encodings now put it in bucket 2.
+  expect_equal(.cfb_era_ordinal(2018, 1), 2)
   expect_equal(unname(.cfb_era_onehot(2018, 1)[1, ]), c(0, 0, 1, 0))
 })
 
 test_that(".cfb_era_ordinal maps every boundary", {
-  s <- c(2000, 2006, 2007, 2013, 2014, 2017, 2018, 2025)
-  expect_equal(.cfb_era_ordinal(s, length(s)), c(0, 0, 1, 1, 2, 2, 3, 3))
+  s <- c(2000, 2006, 2007, 2013, 2014, 2017, 2018, 2020, 2021, 2025)
+  expect_equal(.cfb_era_ordinal(s, length(s)), c(0, 0, 1, 1, 2, 2, 2, 2, 3, 3))
 })
 
 test_that(".cfb_era_ordinal recycles a scalar season", {


### PR DESCRIPTION
Fixes the consumer half of sportsdataverse/cfbfastR-cfb-data#70.

## The bug

The ordinal `era` column was cut at 2006/2013/**2017**, so seasons **2018–2020** were
scored as era 3 against models that trained them as era **2**.

## Which side is wrong — settled against the producer

`cfbfastR-cfb-data/python/cfb_model_build/model_training/constants.py` defines a single
`ERA_BOUNDS = (2006, 2013, 2020)` that **both** `_era()` (ordinal) and `_era_onehot()`
derive from, and `git log -S 2017` over that file shows a 2017 cut has never existed there.

That repo is confirmed as the source of the shipped artifacts — its hyperparameters
reproduce the published cards exactly:

| | trainer | `xpass_model.card.json` |
|---|---|---|
| params | `max_depth=5, eta=0.1, subsample=0.8, colsample_bytree=0.8, min_child_weight=20` | identical |
| rounds | `XPASS_NROUNDS = 150` | `num_boost_round: 150` |

(`two_pt` matches the same way: `max_depth=2, eta=0.05, subsample=0.9, min_child_weight=40`, 40 rounds.)

So the consumers were wrong, not the trainer.

## Where the wrong number came from

This file cited sdv-py as carrying a 2017 ordinal cut. sdv-py's
`cfb_two_point.py::_era` **code** reads `FD_ERA_BOUNDS` (2020) and always has — only its
**docstring** said 2017. The docstring was ported instead of the code. sdv-py's
`__process_xpass` had *separately* hard-coded `<= 2017` inline; both are fixed in
sportsdataverse/sportsdataverse-py#463.

## Impact

`era` takes 251 splits and ~1.1% of gain in `xpass_model`. Across 630 realistic
situations, scoring era 3 instead of era 2 moves `xpass` by a **mean of 0.9 pp, max
2.9 pp**, inherited by `pass_oe` as a step at the 2017/2018 boundary.

`prob_2pt` is **unaffected** — that model never splits on `era` (sportsdataverse/sportsdataverse-py#457).

## What changed

`.XPASS_ERA_CUTS` and `.FG_ERA_CUTS` now hold the same cutpoints but stay **separate
constants**: the *encodings* still differ (one ordinal 0–3 column vs four one-hot
dummies), and conflating the shapes mislabels every season, not just 2018–2020.

## Tests

Four files asserted the old divergence at 2018. `test-xpass_model_artifacts.R` flips
`expect_false(identical(...))` → `expect_identical`, expects `.cfb_era_ordinal(2018) == 2`,
and extends the boundary sweep through 2020/2021; the other three carried it only in
comments.

**Verified the assertions bite:** restoring the 2017 cut fails 4 of them. **103 pass,
0 fail** across the five model-artifact test files.

## Follow-up (not in this PR)

Published pbp assets carry `xpass`/`pass_oe` computed with the old cut — **2018–2020 need
a republish** to pick this up.

## Summary by Sourcery

Align consumer era scoring with the model producer’s training boundaries so 2018–2020 plays receive the correct xpass and two-point model inputs.

Bug Fixes:
- Correct xpass and two-point model era scoring for seasons 2018–2020 by aligning ordinal era cutpoints with the producer’s 2006/2013/2020 training boundaries.

Enhancements:
- Clarify that ordinal and one-hot era features share cutpoints while retaining distinct feature encodings.

Documentation:
- Update release notes and model-artifact documentation to describe the corrected era boundaries and their scoring impact.

Tests:
- Update model-artifact tests to verify the shared 2020 cutpoint and ordinal era mappings through the 2021 boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected expected-pass and two-point conversion era classification for the 2018–2020 seasons.
  * These seasons are now consistently assigned to era 2, matching field-goal and fourth-down model era boundaries.
  * Improved model scoring consistency at the 2020–2021 era boundary.

* **Tests**
  * Updated era-boundary coverage and related documentation to reflect the corrected classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->