### PR TITLE
fix(ci): green main -- unconditional source install for pkgdown, and guard every roster fetch

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -52,6 +52,16 @@ jobs:
           pak::pkg_install("UrbanInstitute/urbnmapr")
         shell: Rscript {0}
 
+      # `local::.` above is a no-op whenever the restored dependency cache
+      # already holds cfbfastR at the same Version. DESCRIPTION has read
+      # 3.0.0.9000 across every dev commit, so pak treats the cached build as
+      # current and pkgdown renders the vignettes against a package that
+      # predates any newly added function -- which is what broke the docs
+      # build on `cfbd_passing_players_season` after #151, while R-CMD-check
+      # (source install every run) stayed green. Install unconditionally.
+      - name: Install cfbfastR from source
+        run: R CMD INSTALL --no-multiarch --with-keep.source .
+
       - name: Deploy package
         run: |
           git config --local user.name "$GITHUB_ACTOR"

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -10,6 +10,12 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-22.04
+    # deploy_to_branch() pushes the built site to gh-pages, so the job needs
+    # contents: write and nothing else. Declared explicitly rather than
+    # inherited: the repository default is currently write, but a default that
+    # flips to read-only would otherwise break the deploy with no change here.
+    permissions:
+      contents: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CFBD_API_KEY: ${{ secrets.CFBD_API_KEY }}

--- a/tests/testthat/test-espn_cfb_team_roster.R
+++ b/tests/testthat/test-espn_cfb_team_roster.R
@@ -25,7 +25,15 @@ test_that("ESPN CFB Team Roster", {
 
   y <- espn_cfb_team_roster(team_id = 61, year = 2023)
 
-  if (is.null(x) || !is.data.frame(x) || nrow(x) == 0) {
+  # team_detail = FALSE / position_detail = FALSE reproduce the base output.
+  z <- espn_cfb_team_roster(team_id = 61, year = 2024,
+                            position_detail = FALSE, team_detail = FALSE)
+
+  # Guard every fetch, not just the first. ESPN can serve one season and not
+  # another, and an unguarded frame then reaches expect_in() with no columns --
+  # which is how this test reddened main while the guarded `x` sailed through.
+  have_roster <- function(d) !is.null(d) && is.data.frame(d) && nrow(d) > 0
+  if (!have_roster(x) || !have_roster(y) || !have_roster(z)) {
     skip("No ESPN team roster data returned at test time")
   }
 
@@ -38,9 +46,6 @@ test_that("ESPN CFB Team Roster", {
   expect_in(team_detail_cols, colnames(x))
   expect_in(position_detail_cols, colnames(x))
 
-  # team_detail = FALSE / position_detail = FALSE reproduce the base output.
-  z <- espn_cfb_team_roster(team_id = 61, year = 2024,
-                            position_detail = FALSE, team_detail = FALSE)
   expect_in(cols, colnames(z))
   expect_false(any(team_detail_cols %in% colnames(z)))
   expect_false(any(position_detail_cols %in% colnames(z)))


### PR DESCRIPTION
Both jobs on `main` went red after #152 merged. Neither was caused by the calculators; both are longer-standing defects that only surface on `main`.

## 1. `pkgdown` -- vignette rendered against a stale install

`vignettes/cfbd_stats.Rmd:146` calls `cfbd_passing_players_season()` and failed with **"could not find function"**, even though the function is defined in `R/cfbd_passing.R:133` and exported at `NAMESPACE:59`.

Root cause is the dependency cache, not the code. `setup-r-dependencies` lists `local::.`, but pak treats that as already satisfied when the restored cache holds `cfbfastR` at the same `Version` -- and `DESCRIPTION` has read `3.0.0.9000` across every dev commit. So pkgdown rendered the vignettes against a build predating #151. `R-CMD-check` never saw it because it installs from source on every run.

This is a general trap, not a one-off: **any** function added without a version bump goes missing from the docs build. Bumping `cache-version` would clear it once and re-break on the next addition, so this installs unconditionally instead.

Verified by running the exact command into a clean library:

```
R CMD INSTALL --no-multiarch --with-keep.source --library=$LIB .
#> * DONE (cfbfastR)
cfbd_passing_players_season        TRUE
cfbd_passing_teams_season          TRUE
cfbd_rushing_players_season        TRUE
calculate_expected_points          TRUE
calculate_field_goal_probability   TRUE
```

## 2. `R-CMD-check` (ubuntu oldrel-1) -- asymmetric skip guard

`test-espn_cfb_team_roster.R` fetches three rosters and skipped on only the first:

```r
x <- espn_cfb_team_roster(team_id = 61, year = 2024)
y <- espn_cfb_team_roster(team_id = 61, year = 2023)
if (is.null(x) || !is.data.frame(x) || nrow(x) == 0) skip(...)   # x only
expect_in(cols, colnames(y))                                     # line 33
```

When ESPN serves 2024 but not 2023, `x` clears the guard and `y` reaches `expect_in()` with no columns. `z` had the same exposure. All three fetches now sit above one `have_roster()` guard.

Verified against live data: **9 passing, 0 skipped**, so the wider guard does not over-skip when ESPN does answer.

## Note on visibility

Both failures were invisible from inside a PR -- `pkgdown` only runs on `push` to `main`, so a docs break cannot fail a PR check. Worth considering running it on PRs too; that is a separate change and not included here.

## Summary by Sourcery

Restore reliable main-branch CI and documentation builds by installing the package from source for pkgdown and guarding all external roster data fetches.

Bug Fixes:
- Ensure pkgdown renders documentation against the current source package instead of a stale cached installation.
- Prevent roster tests from failing when any individual ESPN season or roster variant is unavailable.

CI:
- Declare the pkgdown workflow's required repository write permission explicitly.

Tests:
- Apply a shared availability guard to every ESPN roster fetch in the team roster test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved roster test handling when seasonal data is unavailable.
  - Tests now skip cleanly if any required roster result is empty, avoiding misleading failures.

- **Chores**
  - Updated documentation publishing permissions to ensure generated site updates can be deployed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->