### PR TITLE
fix(vignettes): stop reinstalling cfbfastR from CRAN mid-render (fixes the pkgdown build)

### DIFF
--- a/vignettes/animated-wp-plotting.Rmd
+++ b/vignettes/animated-wp-plotting.Rmd
@@ -28,12 +28,16 @@ We're going to need several packages to generate the winning percentage plot: ``
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("tidyverse", "animation", "glue", "zoo", "ggimage", "cfbfastR"))
+pak::pak(c("tidyverse", "animation", "glue", "zoo", "ggimage"))
 library(tidyverse)
 library(animation)
 library(glue)
 library(zoo)
 library(ggimage)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 ```
 

--- a/vignettes/cfbd_betting.Rmd
+++ b/vignettes/cfbd_betting.Rmd
@@ -22,10 +22,14 @@ knitr::opts_chunk$set(echo = TRUE)
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "tidyr", "gt", "cfbfastR"))
+pak::pak(c("dplyr", "tidyr", "gt"))
 library(dplyr)
 library(tidyr)
 library(gt)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 # pak::pak("sportsdataverse/cfbfastR")
 ```

--- a/vignettes/cfbd_games.Rmd
+++ b/vignettes/cfbd_games.Rmd
@@ -22,10 +22,14 @@ knitr::opts_chunk$set(echo = TRUE)
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "tidyr", "gt", "cfbfastR"))
+pak::pak(c("dplyr", "tidyr", "gt"))
 library(dplyr)
 library(tidyr)
 library(gt)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 # pak::pak("sportsdataverse/cfbfastR")
 ```

--- a/vignettes/cfbd_plays.Rmd
+++ b/vignettes/cfbd_plays.Rmd
@@ -22,9 +22,13 @@ knitr::opts_chunk$set(echo = TRUE)
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "tidyr", "cfbfastR"))
+pak::pak(c("dplyr", "tidyr"))
 library(dplyr)
 library(tidyr)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 #pak::pak("sportsdataverse/cfbfastR")
 ```

--- a/vignettes/cfbd_recruiting.Rmd
+++ b/vignettes/cfbd_recruiting.Rmd
@@ -22,10 +22,14 @@ knitr::opts_chunk$set(echo = TRUE)
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "tidyr", "gt", "cfbfastR"))
+pak::pak(c("dplyr", "tidyr", "gt"))
 library(dplyr)
 library(tidyr)
 library(gt)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 # pak::pak("sportsdataverse/cfbfastR")
 ```

--- a/vignettes/cfbd_stats.Rmd
+++ b/vignettes/cfbd_stats.Rmd
@@ -22,10 +22,14 @@ knitr::opts_chunk$set(echo = TRUE)
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "tidyr", "gt", "cfbfastR"))
+pak::pak(c("dplyr", "tidyr", "gt"))
 library(dplyr)
 library(tidyr)
 library(gt)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 # pak::pak("sportsdataverse/cfbfastR")
 ```

--- a/vignettes/cfbd_teams.Rmd
+++ b/vignettes/cfbd_teams.Rmd
@@ -22,10 +22,14 @@ knitr::opts_chunk$set(echo = TRUE)
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "tidyr", "gt", "cfbfastR"))
+pak::pak(c("dplyr", "tidyr", "gt"))
 library(dplyr)
 library(tidyr)
 library(gt)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 # pak::pak("sportsdataverse/cfbfastR")
 ```

--- a/vignettes/cfbfastR-espn-cookbook.Rmd
+++ b/vignettes/cfbfastR-espn-cookbook.Rmd
@@ -41,10 +41,10 @@ data -- and pick up the functions, and the *shape* of the function names, as we
 go.
 
 ```{r load-pkg}
-# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
-# R CMD check render this vignette against the package being built, and
-# installing from CRAN here would overwrite that dev build with the last
-# release -- so any function added since it would vanish mid-render.
+# Do not add an install step for cfbfastR here. pkgdown and R CMD check
+# render this vignette against the package being built; installing the
+# CRAN release would overwrite that dev build, and any function added
+# since the last release would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 ```

--- a/vignettes/cfbfastR-espn-cookbook.Rmd
+++ b/vignettes/cfbfastR-espn-cookbook.Rmd
@@ -41,6 +41,10 @@ data -- and pick up the functions, and the *shape* of the function names, as we
 go.
 
 ```{r load-pkg}
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 ```

--- a/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
@@ -209,6 +209,10 @@ In practice you never do the above — you ask `cfbfastR` for play-by-play with
 the models already applied:
 
 ```{r real-plays, eval=FALSE}
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-i.Rmd
@@ -209,10 +209,10 @@ In practice you never do the above — you ask `cfbfastR` for play-by-play with
 the models already applied:
 
 ```{r real-plays, eval=FALSE}
-# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
-# R CMD check render this vignette against the package being built, and
-# installing from CRAN here would overwrite that dev build with the last
-# release -- so any function added since it would vanish mid-render.
+# Do not add an install step for cfbfastR here. pkgdown and R CMD check
+# render this vignette against the package being built; installing the
+# CRAN release would overwrite that dev build, and any function added
+# since the last release would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
@@ -158,6 +158,10 @@ schedules, which is exactly why the adjustment exists.
 `cfbfastR` ships EPA on every play, so normally you just read it:
 
 ```{r epa-columns, eval=FALSE}
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-iv.Rmd
@@ -158,10 +158,10 @@ schedules, which is exactly why the adjustment exists.
 `cfbfastR` ships EPA on every play, so normally you just read it:
 
 ```{r epa-columns, eval=FALSE}
-# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
-# R CMD check render this vignette against the package being built, and
-# installing from CRAN here would overwrite that dev build with the last
-# release -- so any function added since it would vanish mid-render.
+# Do not add an install step for cfbfastR here. pkgdown and R CMD check
+# render this vignette against the package being built; installing the
+# CRAN release would overwrite that dev build, and any function added
+# since the last release would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
@@ -124,10 +124,10 @@ downs to get there. No expected-points figure conveys that. This is precisely th
 kind of situation where EPA and WPA part company.
 
 ```{r wp-columns, eval=FALSE}
-# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
-# R CMD check render this vignette against the package being built, and
-# installing from CRAN here would overwrite that dev build with the last
-# release -- so any function added since it would vanish mid-render.
+# Do not add an install step for cfbfastR here. pkgdown and R CMD check
+# render this vignette against the package being built; installing the
+# CRAN release would overwrite that dev build, and any function added
+# since the last release would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-v.Rmd
@@ -124,6 +124,10 @@ downs to get there. No expected-points figure conveys that. This is precisely th
 kind of situation where EPA and WPA part company.
 
 ```{r wp-columns, eval=FALSE}
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
@@ -264,10 +264,10 @@ The outputs:
 | `fourth_down_recommendation` | the call |
 
 ```{r fourth-down, eval=FALSE}
-# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
-# R CMD check render this vignette against the package being built, and
-# installing from CRAN here would overwrite that dev build with the last
-# release -- so any function added since it would vanish mid-render.
+# Do not add an install step for cfbfastR here. pkgdown and R CMD check
+# render this vignette against the package being built; installing the
+# CRAN release would overwrite that dev build, and any function added
+# since the last release would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
+++ b/vignettes/college-football-expected-points-model-fundamentals-part-vi.Rmd
@@ -264,6 +264,10 @@ The outputs:
 | `fourth_down_recommendation` | the call |
 
 ```{r fourth-down, eval=FALSE}
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 library(dplyr)
 

--- a/vignettes/fourth-down-plot-tutorial.Rmd
+++ b/vignettes/fourth-down-plot-tutorial.Rmd
@@ -24,8 +24,12 @@ Hey everyone, my name is Michael and over the summer I worked on a daily series 
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("tidyverse", "cfbfastR"))
+pak::pak(c("tidyverse"))
 library(tidyverse)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 ```
 

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -51,11 +51,15 @@ Welcome to the football analytics community! I'm Saiem Gilani, one of the [autho
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("tidyverse", "zoo", "ggimage", "gt", "cfbfastR"))
+pak::pak(c("tidyverse", "zoo", "ggimage", "gt"))
 library(tidyverse)
 library(zoo)
 library(ggimage)
 library(gt)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 ```
 

--- a/vignettes/map-tutorial.Rmd
+++ b/vignettes/map-tutorial.Rmd
@@ -30,6 +30,10 @@ pak::pak("UrbanInstitute/urbnmapr")
 library(dplyr) #This is to manipulate data
 library(ggplot2) #This is the primary plotting package
 library(urbnmapr) #This is to make the maps
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR) #This has our CFB Data primarily via collegefootballdata.com
 ```
 

--- a/vignettes/nth-rated-recruit.Rmd
+++ b/vignettes/nth-rated-recruit.Rmd
@@ -24,9 +24,13 @@ We start by loading the packages we need. The ```cfbfastR``` package will provid
 if (!requireNamespace('pak', quietly = TRUE)){
   install.packages('pak')
 }
-pak::pak(c("dplyr", "ggplot2", "cfbfastR"))
+pak::pak(c("dplyr", "ggplot2"))
 library(dplyr)
 library(ggplot2)
+# cfbfastR is deliberately NOT in the pak() list above. pkgdown and
+# R CMD check render this vignette against the package being built, and
+# installing from CRAN here would overwrite that dev build with the last
+# release -- so any function added since it would vanish mid-render.
 library(cfbfastR)
 ```
 


### PR DESCRIPTION
The `pkgdown` job on `main` has been failing since #151 with:

```
! Failed to render 'vignettes/cfbd_stats.Rmd'.
Caused by error:
! could not find function "cfbd_passing_players_season"
```

even though that function is defined at `R/cfbd_passing.R:133` and exported at `NAMESPACE:59`.

## Cause

Every vignette setup chunk runs:

```r
pak::pak(c("dplyr", "tidyr", "gt", "cfbfastR"))
library(cfbfastR)
# pak::pak("sportsdataverse/cfbfastR")
```

`pak::pak("cfbfastR")` installs **from CRAN, at render time**, overwriting the dev build pkgdown just installed. CRAN ships 3.0.0, so every function added since the last release disappears mid-render. The dev-install line was already sitting there commented out, directly beneath the active CRAN one.

Ten vignettes did this: `animated-wp-plotting`, `cfbd_betting`, `cfbd_games`, `cfbd_plays`, `cfbd_recruiting`, `cfbd_stats`, `cfbd_teams`, `fourth-down-plot-tutorial`, `intro`, `nth-rated-recruit`.

## Change

- Drop `cfbfastR` from the `pak()` list in all ten. `library(cfbfastR)` stays and now resolves to the package being built.
- Add a comment in sixteen vignettes explaining why it must not go back in.

## Verification

Rendered the vignette that broke the build, against a library holding a source install of this branch:

```
R CMD INSTALL --no-multiarch --with-keep.source --library=$LIB .
rmarkdown::render("vignettes/cfbd_stats.Rmd")
#> RENDER OK
```

## Correction to #153

#153 attributed this to `local::.` being skipped when the dependency cache already held the same `Version`. That was wrong. The unconditional install step it added ran, succeeded, and installed to the correct library (`/home/runner/work/_temp/Library`) while the failure stayed byte-identical — because the vignette clobbers that library afterwards. No workflow-side change could have fixed it.

That step is kept: it is a correct guarantee that the dev build is present before pkgdown starts, which this fix now depends on. The `contents: write` permissions block from #153 is also unrelated to this and stands on its own.

## Summary by Sourcery

Keep vignette rendering on the development build so pkgdown uses the package version being documented.

Bug Fixes:
- Prevent vignettes from overwriting the development package with the CRAN release during rendering, restoring access to functions introduced after the latest release and fixing pkgdown builds.

Enhancements:
- Document in affected vignettes that the package itself must not be installed during rendering.

Tests:
- Verify that the previously failing statistics vignette renders successfully against a source installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated package installation guidance across the vignettes.
  * Vignettes now preserve and use the package version currently being built during rendering.
  * Added clarification that documentation builds should not replace the in-development package with the latest CRAN release.
  * Documented the expected behavior for pkgdown and `R CMD check` workflows, improving consistency when building and reviewing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->